### PR TITLE
save  beamtilt

### DIFF
--- a/relion/convert/convert.py
+++ b/relion/convert/convert.py
@@ -113,21 +113,21 @@ def rowToObject(row, obj, attrDict, extraLabels=[]):
             as properties with the label name such as: _rlnSomeThing
     """
     obj.setEnabled(row.getValue(md.RLN_IMAGE_ENABLED, 1) > 0)
-    
+
     for attr, label in attrDict.iteritems():
         value = row.getValue(label)
         if not hasattr(obj, attr):
             setattr(obj, attr, ObjectWrap(value))
         else:
             getattr(obj, attr).set(value)
-        
+
     attrLabels = attrDict.values()
-    
+
     for label in extraLabels:
         if label not in attrLabels and row.hasLabel(label):
             labelStr = md.label2Str(label)
             setattr(obj, '_' + labelStr, row.getValueAsObject(label))
-    
+
 
 def setObjId(obj, mdRow, label=md.RLN_IMAGE_ID):
     obj.setObjId(mdRow.getValue(label, None))
@@ -387,6 +387,11 @@ def particleToRow(part, partRow, **kwargs):
     if kwargs.get('fillRandomSubset') and part.hasAttribute('_rlnRandomSubset'):
         partRow.setValue(md.RLN_PARTICLE_RANDOM_SUBSET,
                          int(part._rlnRandomSubset.get()))
+        if part.hasAttribute('_rlnBeamTiltX'):
+            partRow.setValue(md.RLN_IMAGE_BEAMTILT_X,
+                         float(part._rlnBeamTiltX.get()))
+            partRow.setValue(md.RLN_IMAGE_BEAMTILT_Y,
+                         float(part._rlnBeamTiltY.get()))
 
     imageToRow(part, partRow, md.RLN_IMAGE_NAME, **kwargs)
 

--- a/relion/protocols/protocol_base.py
+++ b/relion/protocols/protocol_base.py
@@ -865,10 +865,6 @@ class ProtRelionBase(EMProtocol):
             hasAlign = alignType != em.ALIGN_NONE
             alignToPrior = hasAlign and getattr(self, 'alignmentAsPriors', False)
             fillRandomSubset = hasAlign and getattr(self, 'fillRandomSubset', False)
-            relion3Labels = [md.RLN_PARTICLE_RANDOM_SUBSET
-                             ,md.RLN_IMAGE_BEAMTILT_X
-                             ,md.RLN_IMAGE_BEAMTILT_Y
-                            ]
 
             relion3Labels = [md.RLN_PARTICLE_RANDOM_SUBSET,
                              md.RLN_IMAGE_BEAMTILT_X,

--- a/relion/protocols/protocol_base.py
+++ b/relion/protocols/protocol_base.py
@@ -865,12 +865,17 @@ class ProtRelionBase(EMProtocol):
             hasAlign = alignType != em.ALIGN_NONE
             alignToPrior = hasAlign and getattr(self, 'alignmentAsPriors', False)
             fillRandomSubset = hasAlign and getattr(self, 'fillRandomSubset', False)
+            relion3Labels = [md.RLN_PARTICLE_RANDOM_SUBSET
+                             ,md.RLN_IMAGE_BEAMTILT_X
+                             ,md.RLN_IMAGE_BEAMTILT_Y
+                            ]
 
             relion.convert.writeSetOfParticles(
                 imgSet, imgStar, self._getExtraPath(),
                 alignType=alignType,
                 postprocessImageRow=self._postprocessParticleRow,
-                fillRandomSubset=fillRandomSubset)
+                fillRandomSubset=fillRandomSubset,
+                extraLabels=relion3Labels)
 
             if alignToPrior:
                 mdParts = md.MetaData(imgStar)

--- a/relion/protocols/protocol_base.py
+++ b/relion/protocols/protocol_base.py
@@ -870,6 +870,10 @@ class ProtRelionBase(EMProtocol):
                              ,md.RLN_IMAGE_BEAMTILT_Y
                             ]
 
+            relion3Labels = [md.RLN_PARTICLE_RANDOM_SUBSET,
+                             md.RLN_IMAGE_BEAMTILT_X,
+                             md.RLN_IMAGE_BEAMTILT_Y]
+
             relion.convert.writeSetOfParticles(
                 imgSet, imgStar, self._getExtraPath(),
                 alignType=alignType,
@@ -1139,14 +1143,14 @@ class ProtRelionBase(EMProtocol):
     def _setMaskArgs(self, args):
         if self.IS_3D:
             if self.referenceMask.hasValue():
-                mask = convertMask(self.referenceMask.get(), self._getTmpPath())
+                mask = relion.convert.convertMask(self.referenceMask.get(), self._getTmpPath())
                 args['--solvent_mask'] = mask
 
             if self.solventMask.hasValue():
-                solventMask = convertMask(self.solventMask.get(), self._getTmpPath())
+                solventMask = relion.convert.convertMask(self.solventMask.get(), self._getTmpPath())
                 args['--solvent_mask2'] = solventMask
 
-            if (self.referenceMask.hasValue() and self.solventFscMask):
+            if self.referenceMask.hasValue() and self.solventFscMask:
                 args['--solvent_correct_fsc'] = ''
 
     def _setSubsetArgs(self, args):

--- a/relion/protocols/protocol_ctf_refinement.py
+++ b/relion/protocols/protocol_ctf_refinement.py
@@ -28,7 +28,7 @@ import pyworkflow.utils as pwutils
 import pyworkflow.protocol.params as params
 import pyworkflow.em as em
 import pyworkflow.em.metadata as md
-
+from pyworkflow.em.data import Float
 import relion
 from relion.convert.metadata import Table
 
@@ -73,12 +73,15 @@ class ProtRelionCtfRefinement(em.ProtParticles):
         form.addParam('minResolution', params.FloatParam, default=30,
                       label='Minimum resolution for fits (A)',
                       help="The minimum spatial frequency (in Angstrom) used "
-                           "in the beamtilt fit.")
-
+                           "in the beamtilt fit. (Default value is usually correct)")
         form.addParam('doCtfFitting', params.BooleanParam, default=True,
                       label='Perform CTF parameter fitting?',
                       help='If set to Yes, then relion_ctf_refine will be '
-                           'used to estimate the selected parameters below.')
+                           'used to estimate the selected parameters below.'
+                           ' (We are interested in re-estimating the defocus'
+                           ' of each particle. This will account for non-horizontal'
+                           ' ice layers, and particles at the top or bottom of'
+                           ' the ice layer.)')
         form.addParam('fitPartDefocus', params.BooleanParam, default=True,
                       condition='doCtfFitting',
                       label='Fit per-particle defocus?',
@@ -88,7 +91,7 @@ class ProtRelionCtfRefinement(em.ProtParticles):
                       condition='doCtfFitting and fitPartDefocus',
                       label='Range for defocus fit (A)',
                       help='The range in (Angstrom) for the defocus fit of '
-                           'each particle.')
+                           'each particle. (Usually, the default value works fine.)')
         form.addParam('fitAstig', params.EnumParam, default=0,
                       choices=['no', 'per-micrograph', 'per-particle'],
                       display=params.EnumParam.DISPLAY_HLIST,
@@ -175,26 +178,32 @@ class ProtRelionCtfRefinement(em.ProtParticles):
 
         args += "--j %d " % self.numberOfThreads
         prog = "relion_ctf_refine" + ("_mpi" if self.numberOfMpi > 1 else "")
+        print (prog, args)
         self.runJob(prog, args)
 
     def createOutputStep(self):
+        #rlnBeamTiltXLabel = md.getNewAlias("rlnBeamTiltX", md.LABEL_DOUBLE)
+        #rlnBeamTiltYLabel = md.getNewAlias("rlnBeamTiltY", md.LABEL_DOUBLE)
         imgSet = self.inputParticles.get()
         outImgSet = self._createSetOfParticles()
         outImgSet.copyInfo(imgSet)
-
         outImgsFn = self._getExtraPath('particles_ctf_refine.star')
         imgSet.setAlignmentProj()
-        rowIterator = md.iterRows(outImgsFn, sortByLabel=md.RLN_IMAGE_ID)
+        rowIterator = md.iterRows(outImgsFn,
+                                  sortByLabel=md.RLN_IMAGE_ID)
         outImgSet.copyItems(imgSet,
-                            updateItemCallback=self._updateItemCtf,
+                            updateItemCallback=self._updateItemCtfBeamTilt,
                             itemDataIterator=rowIterator)
-
         self._defineOutputs(outputParticles=outImgSet)
         self._defineTransformRelation(self.inputParticles, outImgSet)
 
-    def _updateItemCtf(self, particle, row):
+    def _updateItemCtfBeamTilt(self, particle, row):
         particle.setCTF(relion.convert.rowToCtfModel(row))
         #TODO: Add other field from the .star file when other options?
+        # check if beamtilt is available and save it
+        if row.hasLabel(md.RLN_IMAGE_BEAMTILT_X):
+            particle._rlnBeamTiltX = Float(row.getValue(md.RLN_IMAGE_BEAMTILT_X, 0))
+            particle._rlnBeamTiltY = Float(row.getValue(md.RLN_IMAGE_BEAMTILT_Y, 0))
 
     # --------------------------- INFO functions ------------------------------
     def _summary(self):

--- a/relion/protocols/protocol_ctf_refinement.py
+++ b/relion/protocols/protocol_ctf_refinement.py
@@ -181,8 +181,6 @@ class ProtRelionCtfRefinement(em.ProtParticles):
         self.runJob(prog, args)
 
     def createOutputStep(self):
-        #rlnBeamTiltXLabel = md.getNewAlias("rlnBeamTiltX", md.LABEL_DOUBLE)
-        #rlnBeamTiltYLabel = md.getNewAlias("rlnBeamTiltY", md.LABEL_DOUBLE)
         imgSet = self.inputParticles.get()
         outImgSet = self._createSetOfParticles()
         outImgSet.copyInfo(imgSet)

--- a/relion/protocols/protocol_ctf_refinement.py
+++ b/relion/protocols/protocol_ctf_refinement.py
@@ -178,7 +178,6 @@ class ProtRelionCtfRefinement(em.ProtParticles):
 
         args += "--j %d " % self.numberOfThreads
         prog = "relion_ctf_refine" + ("_mpi" if self.numberOfMpi > 1 else "")
-        print (prog, args)
         self.runJob(prog, args)
 
     def createOutputStep(self):

--- a/relion/protocols/protocol_extract_particles.py
+++ b/relion/protocols/protocol_extract_particles.py
@@ -82,7 +82,7 @@ class ProtRelionExtractParticles(pw.em.ProtExtractParticles, ProtRelionBase):
 
         form.addParam('backDiameter', params.IntParam, default=-1,
                       condition='doNormalize',
-                      label='Diameter background circle (px)',
+                      label='Diameter background circle before scaling (px)',
                       help='Particles will be normalized to a mean value of '
                            'zero and a standard-deviation of one for all '
                            'pixels in the background area. The background area '
@@ -254,6 +254,7 @@ class ProtRelionExtractParticles(pw.em.ProtExtractParticles, ProtRelionBase):
         params += ' --coord_suffix .coords.star'
         params += ' --part_dir "." --extract '
         params += ' --extract_size %d' % self.boxSize
+        params += ' --set_angpix %f' % self._getNewSampling()
 
         if self.backDiameter <= 0:
             diameter = self.boxSize.get() * 0.75

--- a/relion/protocols/protocol_reconstruct.py
+++ b/relion/protocols/protocol_reconstruct.py
@@ -123,7 +123,9 @@ class ProtRelionReconstruct(ProtReconstruct3D):
         if self.numberOfMpi > 1:
             program += '_mpi'
         if self.numberOfThreads > 1 and not IS_V2:
-            program += '_openmp'
+            # TODO: comment josemiguel
+            pass #
+            # program += '_openmp'
         return program
 
     def _insertReconstructStep(self):

--- a/tests/kk.py
+++ b/tests/kk.py
@@ -1,0 +1,57 @@
+from __future__ import print_function
+"""
+edit file postprocess.star and add to
+
+data_general
+
+_rlnFinalResolution                           5.541053
+_rlnBfactorUsedForSharpening               -439.707536
+_rlnFittedSlopeGuinierPlot                 -109.926884
+_rlnFittedInterceptGuinierPlot              -13.944270
+_rlnCorrelationFitGuinierPlot                 0.962517
+
+
+_rlnUnfilteredMapHalf1                    Runs/008287_ProtRelionRefine3D/extra/relion_half1_class001_unfil.mrc
+_rlnUnfilteredMapHalf2                    Runs/008287_ProtRelionRefine3D/extra/relion_half1_class002_unfil.mrc
+_rlnMaskName                              Runs/009075_ProtRelionPostprocess/extra/cess/input/postprocess_automask.mrc
+_rlnRandomiseFrom                             7.91579
+
+Randon noise is in the stdout of postprocess
+
+"""
+
+"""
+file input_particles.start
+does not have column rlnRandomSubset
+put this available in star file in
+"""
+
+import pyworkflow.em as em
+import pyworkflow.em.metadata as md
+from pyworkflow.em.constants import ALIGN_PROJ
+
+import relion
+from relion.convert.metadata import Table
+
+# fnStar = '/home/roberto/ScipionUserData/projects/20170529_CARMENSM_delta7_crio_tomo_4_control_wt/Runs/008287_ProtRelionRefine3D/extra/relion_data.star'
+#fnStar = '/home/roberto/tmp/relion_data.star'
+fnStar = '/home/roberto/ScipionUserData/projects/20170529_CARMENSM_delta7_crio_tomo_4_control_wt/Runs/010387_ProtRelionCtfRefinement/extra/particles_ctf_refine.star'
+mdAll = md.MetaData(fnStar)
+# extraLabels = [md.RLN_PARTICLE_RANDOM_SUBSET]
+extraLabels = [md.RLN_PARTICLE_RANDOM_SUBSET,
+               md.RLN_IMAGE_BEAMTILT_X,
+               md.RLN_IMAGE_BEAMTILT_Y]
+imgSet = em.SetOfParticles(filename="particles_v2.sqlite")
+alignType = ALIGN_PROJ
+relion.convert.readSetOfParticles(fnStar,imgSet,
+                                  alignType=alignType,
+                                  extraLabels=extraLabels)  # _rlnRandomSubset
+imgSet.write()
+
+# writeSqliteIterData
+#relion.convert.writeSetOfParticles(inputParts, imgStar, inputFolder,
+#                                    alignType=em.ALIGN_PROJ,
+#                                    fillMagnification=True,
+#                                    fillRandomSubset=True)
+
+


### PR DESCRIPTION
This pull request has two purposes

   1) save beamtiltX and beamtiltY parameters in setOfParticles
   2) relion_reconstruct  is called (in relion3 version) as  relion_reconstruct_openmp. In my version of relion3 the correct name is relion_reconstruct (no openmp) and I can not see any flag that will create the openmp version.

