### PR TITLE
Including postprocess to protocol.conf

### DIFF
--- a/relion/protocols.conf
+++ b/relion/protocols.conf
@@ -43,7 +43,9 @@ Protocols SPA = [
 			{"tag": "protocol", "value": "ProtRelionCtfRefinement",   "text": "default"},	
 			{"tag": "protocol", "value": "ProtRelionPolish", "text": "default"}			
 		]},
-		{"tag": "section", "text": "Resolution", "openItem": "False", "children": []},		
+		{"tag": "section", "text": "Postprocess", "openItem": "False", "children": [
+		    {"tag": "protocol", "value": "ProtRelionPostprocess",   "text": "default"}
+		]},
 		{"tag": "protocol_group", "text": "Reconstruct", "openItem": "False", "children": [
 			{"tag": "protocol", "value": "ProtRelionReconstruct",   "text": "default"}
 		]}


### PR DESCRIPTION
Xmipp (localSharpening) and LocScale already have this section and it make sense to also include RelionPostProcess.

Additionally, I've removed the Resolution section bad allocated here. Usually it is inside the Validation section and, then, this bad allocation was generating an empty entrance.

After this PR, the 3D section looks like:
![image](https://user-images.githubusercontent.com/30288932/56797675-8070f880-6815-11e9-83ac-8f46ab1b3d95.png)
