### PR TITLE
use-specific-gold-vol-in-reconstruction-test

### DIFF
--- a/relion/tests/test_convert_relion.py
+++ b/relion/tests/test_convert_relion.py
@@ -287,7 +287,9 @@ class TestConvertAnglesBase(BaseTest):
             goldFn = self.dataset.getFile(fileKey + '_Gold_output_relion.mrcs')
         else:
             outputFn = self.getOutputPath(fileKey + "_output.vol")
-            goldFn = self.dataset.getFile(fileKey + '_Gold_output.vol')
+            # Once version has this key in the dataset this can be uncommented (v >2.0)
+            #goldFn = self.dataset.getFile(fileKey + 'GoldRln')
+            goldFn = self.dataset.getFile("reconstruction/gold/" + fileKey + '_Gold_rln_output.vol')
 
         if PRINT_FILES:
             print("BINARY DATA: ", stackFn)


### PR DESCRIPTION
for some reason the reconstruction test is failing, not in all machines. We @rmarabini and myself had a look to the gold .vol that are the expected results and they do not seem to be consistent with the mrcs files used for the reconstruction.

I've added specific -vol for relion.