### PR TITLE
calls the right commands in the picking wizzard still it does not ...

### DIFF
--- a/relion/wizards.py
+++ b/relion/wizards.py
@@ -201,15 +201,14 @@ class Relion2AutopickParams(EmWizard):
         pwutils.copyPattern(autopickProt._getExtraPath("*autopick.star"),
                             backupDir)
 
-        cmd = 'python -m %s relion_autopick ' % SCIPION_EP
-        # cmd += '--i extra/%(micrographName).star '
+        cmd = 'emprogram relion_autopick '
         cmd += '--i input_micrographs.star '
         cmd += '--threshold %(threshold) --min_distance %(ipd) '
         cmd += ' --max_stddev_noise %(maxStddevNoise) '
         cmd += ' --read_fom_maps'
         cmd += autopickProt.getAutopickParams()
 
-        convertCmd = pwem.join('cmd', 'convert.py')
+        convertCmd = 'emconvert'
         convertCmd += ' --coordinates --from relion --to xmipp '
         convertCmd += ' --input %s' % micSet.getFileName()
         convertCmd += ' --output %s' % coordsDir


### PR DESCRIPTION
…work due to some missing star files that escapes my understanding.

This calls the right commands for the wizard to work. But is not fixed due to some missing starfiles.

It seems there are meant to be starfiles at extra path, and a backup is happening. But I don't have those files in my execution.