### PR TITLE
Move code used by several viewers from the plugin to scipion-em

### DIFF
--- a/relion/viewers/viewer_locres.py
+++ b/relion/viewers/viewer_locres.py
@@ -23,7 +23,7 @@
 # *  e-mail address 'scipion@cnb.csic.es'
 # *
 # ******************************************************************************
-
+from pwem.viewers.viewer_chimera import mapVolsWithColorkey
 from pyworkflow.viewer import ProtocolViewer
 from pwem.emlib.image import ImageHandler
 
@@ -83,7 +83,7 @@ class RelionLocalResViewer(ProtocolViewer):
     # =============================================================================
     def _showVolumeSlices(self, param=None):
         imageFile = self.protocol._getFileName('resolMap')
-        imgData, minRes, maxRes = self._getImgData(imageFile)
+        imgData, minRes, maxRes, volDim = self._getImgData(imageFile)
 
         xplotter = RelionPlotter(x=2, y=2, mainTitle="Local Resolution Slices "
                                                      "along %s-axis."
@@ -117,12 +117,12 @@ class RelionLocalResViewer(ProtocolViewer):
         import numpy as np
         img = ImageHandler().read(imgFile + ":mrc")
         imgData = img.getData()
-
+        voldim = (img.getDimensions())[:-1]
         maxRes = np.amax(imgData)
         imgData2 = np.ma.masked_where(imgData < 0.1, imgData, copy=True)
         minRes = np.amin(imgData2)
 
-        return imgData2, minRes, maxRes
+        return imgData2, minRes, maxRes, voldim
 
     def _getSlice(self, index, volumeData):
         return int((index + 3) * volumeData.shape[0] / 9)
@@ -145,67 +145,25 @@ class RelionLocalResViewer(ProtocolViewer):
 
     def _createChimeraScript(self, scriptFile):
         import pyworkflow.gui.plotter as plotter
-        fhCmd = open(scriptFile, 'w')
         imageFile = os.path.abspath(self.protocol._getFileName('resolMap'))
-
-        _, minRes, maxRes = self._getImgData(imageFile)
+        _, minRes, maxRes, voldim = self._getImgData(imageFile)
 
         stepColors = self._getStepColors(minRes, maxRes)
         colorList = plotter.getHexColorList(stepColors, self._getColorName())
 
         fnVol = os.path.abspath(self.protocol._getFileName('outputVolume'))
-        fhCmd.write("from chimerax.core.commands import run\n")
-        # import need to place the labels in the proper place
-        fhCmd.write("from chimerax.graphics.windowsize import window_size\n")
-        # import needed to cmpute font size in pixels.
-        fhCmd.write("from PyQt5.QtGui import QFontMetrics\n")
-        fhCmd.write("from PyQt5.QtGui import QFont\n")
-        fhCmd.write("run(session, 'set bgColor white')\n")
-        fhCmd.write("run(session, 'open %s')\n" % fnVol)
-        fhCmd.write("run(session, 'open %s')\n" % imageFile)
-
         sampRate = self.protocol.outputVolume.getSamplingRate()
-
-        counter = 1
-        fhCmd.write("run(session, 'volume #%d voxelSize %s')\n" % (counter, str(sampRate)))
-        counter += 1
-        fhCmd.write("run(session, 'volume #%d voxelSize %s')\n" % (counter, str(sampRate)))
-        fhCmd.write("run(session, 'hide #%d')\n" % counter)
-
-
-        scolorStr = ''
-        for step, color in zip(stepColors, colorList):
-            scolorStr += '%s,%s:' % (step, color)
-        scolorStr = scolorStr[:-1]
-        fhCmd.write("run(session, 'color sample #1 map #2 palette " + scolorStr + "')\n")
-        counter = 0
-        # chimera X has no equivalent to colorkey
-        # be default chimera uses ariel although
-        # the actual font is not very important
-        # since the height is almost the same
-        # for a given size
-        # get font size in pixels
-        ptSize = 12
-        fhCmd.write('font = QFont("Ariel", %d)\n' % ptSize)
-        fhCmd.write('f = QFontMetrics(font)\n')
-        fhCmd.write('_height =  1 * f.height()\n')
-        fhCmd.write("v = session.main_view\n")
-        # get window size
-        fhCmd.write("vx,vy=v.window_size\n")
-        fhCmd.write("step = ")
-        # place labels in right place
-        # unfortunatelly chimera has no colorbar
-        for step, color in zip(stepColors, colorList):
-            step = "%0.2f" % step
-            command ='run(session, "2dlabel text ' + step + \
-            ' bgColor ' + color + \
-            ' xpos 0.01 ypos %f' + \
-            ' size ' + str(ptSize) + \
-            '" % ' +\
-           '(%f*_height/vx))\n' % (counter)
-            fhCmd.write(command)
-            counter += 2
-        fhCmd.close()
+        mapVolsWithColorkey(fnVol,
+                            imageFile,
+                            stepColors,
+                            colorList,
+                            voldim,
+                            volOrigin=None,
+                            step = -1,
+                            sampling=sampRate,
+                            scriptFileName=scriptFile,
+                            bgColorImage='white',
+                            showAxis=True)
 
     def _getStepColors(self, minRes, maxRes, numberOfColors=13):
         inter = (maxRes - minRes) / (numberOfColors - 1)


### PR DESCRIPTION
mapVolsWithColorkey function has been added to scipion-em  in order to encapsulate the chimera commands
"scolor" + "colorkey". Note that chimerax does not longer support colorkey.

You will need to update  scipion-em  in order to check this pull request.