### PR TITLE
pickers refactoring

### DIFF
--- a/relion/constants.py
+++ b/relion/constants.py
@@ -50,12 +50,6 @@ OTHER = 1
 REF_AVERAGES = 0
 REF_VOLUME = REF_BLOBS = 1
 
-RUN_OPTIMIZE = 0  # Run only on several micrographs to optimize parameters
-RUN_COMPUTE = 1  # Run the picking for all micrographs after optimize
-
-MICS_AUTO = 0
-MICS_SUBSET = 1
-
 # Used in ctf-refinment
 FIT_NO = 0
 FIT_MICS = 1

--- a/relion/convert/__init__.py
+++ b/relion/convert/__init__.py
@@ -230,7 +230,7 @@ class DefocusGroups:
             # Only when we reach the min number of particles
             # and the defocus difference, we create a new group
             if (group.count >= minGroupSize
-                and (defocus - group.minDefocus > defocusDiff)):
+                    and (defocus - group.minDefocus > defocusDiff)):
                 group = self.__addGroup()
 
             group.addDefocus(defocus)
@@ -238,7 +238,7 @@ class DefocusGroups:
     def getGroup(self, defocus):
         """ Return the group that this defocus belong. """
         if (defocus < self._groups[0].minDefocus
-            or defocus > self._groups[-1].maxDefocus):
+                or defocus > self._groups[-1].maxDefocus):
             return None
 
         for group in self._groups:

--- a/relion/convert/convert30.py
+++ b/relion/convert/convert30.py
@@ -33,7 +33,7 @@ import pwem.convert.transformations as tfs
 
 from ..constants import *
 from .convert_base import WriterBase, ReaderBase
-from .convert_deprecated import rowToAlignment, readSetOfParticles
+from .convert_deprecated import readSetOfParticles
 
 
 class Writer(WriterBase):

--- a/relion/convert/convert31.py
+++ b/relion/convert/convert31.py
@@ -48,7 +48,7 @@ from relion.constants import PARTICLE_EXTRA_LABELS
 def getPixelSizeLabel(imageSet):
     """ Return the proper label for pixel size. """
     if (isinstance(imageSet, SetOfMicrographsBase)
-        or isinstance(imageSet, Micrograph)):
+            or isinstance(imageSet, Micrograph)):
         return 'rlnMicrographPixelSize'
     else:
         return 'rlnImagePixelSize'
@@ -58,6 +58,7 @@ class OpticsGroups:
     """ Store information about optics groups in an indexable way.
     Existing groups can be accessed by number of name.
     """
+
     def __init__(self, opticsTable):
         self.__fromTable(opticsTable)
 
@@ -107,7 +108,7 @@ class OpticsGroups:
     def updateAll(self, **kwargs):
         """ Update all Optics Groups with these values. """
         missing = {k: v for k, v in kwargs.items() if not self.hasColumn(k)}
-        existing  = {k: v for k, v in kwargs.items() if self.hasColumn(k)}
+        existing = {k: v for k, v in kwargs.items() if self.hasColumn(k)}
 
         self.addColumns(**missing)
 
@@ -189,7 +190,7 @@ opticsGroup1            1      1.000000   300.000000     2.700000     0.100000  
 
         og = OpticsGroups.fromString(opticsString1)
         fog = og.first()
-        newColumns = {k:v for k, v in kwargs.items() if not hasattr(fog, k)}
+        newColumns = {k: v for k, v in kwargs.items() if not hasattr(fog, k)}
         og.addColumns(**newColumns)
         og.update(1, **kwargs)
         return og
@@ -228,6 +229,7 @@ class Writer(WriterBase):
     """ Helper class to convert from Scipion SetOfImages subclasses
     into Relion>3.1 star files (and binaries if conversion needed).
     """
+
     def writeSetOfMovies(self, moviesIterable, starFile, **kwargs):
         self._writeSetOfMoviesOrMics(moviesIterable, starFile,
                                      'movies', 'rlnMicrographMovieName',
@@ -379,7 +381,6 @@ class Writer(WriterBase):
         # when flags are True, some operations will be applied to all particles
         self._preprocessImageRow = kwargs.get('preprocessImageRow', None)
 
-
         self._setCtf = kwargs.get('writeCtf', True) and firstPart.hasCTF()
 
         alignType = kwargs.get('alignType', partsSet.getAlignment())
@@ -451,7 +452,6 @@ class Writer(WriterBase):
 
 
 class Reader(ReaderBase):
-
     ALIGNMENT_LABELS = [
         "rlnOriginXAngst",
         "rlnOriginYAngst",
@@ -558,7 +558,7 @@ class Reader(ReaderBase):
         for label in self._extraLabels:
             getattr(particle, '_%s' % label).set(getattr(row, label))
 
-        #TODO: coord, partId, micId,
+        # TODO: coord, partId, micId,
 
         if self._postprocessImageRow:
             self._postprocessImageRow(particle, row)

--- a/relion/convert/convert_coordinates.py
+++ b/relion/convert/convert_coordinates.py
@@ -183,7 +183,6 @@ def writeCoordsConfig(configFn, boxSize, state):
     table.write(configFn, tableName='properties')
 
 
-
 def openMd(fn, state='Manual'):
     # We are going to write metadata directly to file to do it faster
     f = open(fn, 'w')

--- a/relion/convert/convert_deprecated.py
+++ b/relion/convert/convert_deprecated.py
@@ -472,7 +472,6 @@ def readSetOfParticles(filename, imgSet, rowToFunc=rowToParticle, **kwargs):
     imgSet.setAlignment(kwargs['alignType'])
 
 
-
 def setOfImagesToMd(imgSet, imgMd, imgToFunc, **kwargs):
     """ This function will fill Relion metadata from a SetOfMicrographs
     Params:

--- a/relion/convert/convert_deprecated.py
+++ b/relion/convert/convert_deprecated.py
@@ -28,8 +28,7 @@
 # *
 # **************************************************************************
 
-import os
-from os.path import join, basename
+from os.path import basename
 import numpy as np
 
 from pyworkflow.object import ObjectWrap, String, Integer

--- a/relion/protocols/_legacy/protocol30_bayesian_polishing.py
+++ b/relion/protocols/_legacy/protocol30_bayesian_polishing.py
@@ -324,7 +324,7 @@ class ProtRelionBayesianPolishing(ProtParticles):
         errors = []
 
         if self.operation == self.OP_TRAIN and self.numberOfMpi > 1:
-                errors.append("Parameter estimation is not supported in MPI mode.")
+            errors.append("Parameter estimation is not supported in MPI mode.")
         return errors
 
     def _getInputPath(self, *paths):

--- a/relion/protocols/protocol_autopick.py
+++ b/relion/protocols/protocol_autopick.py
@@ -53,8 +53,6 @@ class ProtRelionAutopickBase(ProtParticlePickingAuto, ProtRelionBase):
         self._pickMicrographsFromStar(micStar, micsDir, *args)
         # Move coordinates files to tmp
         os.system('mv %s/*autopick.star %s/' % (micsDir, self._getTmpPath()))
-        if self.isRunOptimize():
-            os.system('mv %s %s/' % (micStar, self._getTmpPath()))
 
     def _createSetOfCoordinates(self, micSet, suffix=''):
         """ Override this method to set the box size. """
@@ -78,9 +76,6 @@ class ProtRelionAutopickBase(ProtParticlePickingAuto, ProtRelionBase):
         """ Return a reasonable box-size in pixels. """
         return None
 
-    def isRunOptimize(self):
-        return False
-
     def getInputMicrographsPointer(self):
         return self.inputMicrographs
 
@@ -88,10 +83,9 @@ class ProtRelionAutopickBase(ProtParticlePickingAuto, ProtRelionBase):
         return self.getInputMicrographsPointer().get()
 
     def getMicrographList(self):
-        """ Return the list of micrographs (either a subset or the full set)
+        """ Return the list of micrographs
         that will be used for optimizing the parameters or the picking.
         """
-        # Use all micrographs only when going for the full picking
         return self.getInputMicrographs()
 
     def getCoordsDir(self):

--- a/relion/protocols/protocol_autopick_log.py
+++ b/relion/protocols/protocol_autopick_log.py
@@ -30,7 +30,6 @@ import pyworkflow.protocol.params as params
 from pyworkflow.protocol import STEPS_SERIAL
 from pwem.protocols import ProtParticlePickingAuto
 
-from relion import Plugin
 from .protocol_autopick import ProtRelionAutopickBase
 
 
@@ -91,19 +90,18 @@ class ProtRelionAutopickLoG(ProtRelionAutopickBase):
                             'threshold) particles compared to the default '
                             'setting.')
 
-        if self.IS_GT30():
-            group.addParam('threshold2', params.FloatParam, default=999,
-                           label='Upper threshold (stddev)',
-                           help='Use this to discard picks with LoG thresholds '
-                                'that are this many standard deviations above '
-                                'the average, e.g. to avoid high contrast '
-                                'contamination like ice and ethane droplets. '
-                                'Good values depend on the contrast of '
-                                'micrographs and need to be interactively '
-                                'explored; for low contrast micrographs, '
-                                'values of ~ 1.5 may be reasonable, but the '
-                                'same value will be too low for high-contrast '
-                                'micrographs.')
+        group.addParam('threshold2', params.FloatParam, default=999,
+                       label='Upper threshold (stddev)',
+                       help='Use this to discard picks with LoG thresholds '
+                            'that are this many standard deviations above '
+                            'the average, e.g. to avoid high contrast '
+                            'contamination like ice and ethane droplets. '
+                            'Good values depend on the contrast of '
+                            'micrographs and need to be interactively '
+                            'explored; for low contrast micrographs, '
+                            'values of ~ 1.5 may be reasonable, but the '
+                            'same value will be too low for high-contrast '
+                            'micrographs.')
 
         form.addParam('extraParams', params.StringParam, default='',
                       label='Additional arguments:',
@@ -122,7 +120,7 @@ class ProtRelionAutopickLoG(ProtRelionAutopickBase):
 
     def getAutopickParams(self):
         """ Return the autopicking parameters except for the interactive ones. """
-        params = ' --pickname autopick --odir "" --LoG --shrink 0'
+        params = ' --pickname autopick --odir "./" --LoG --shrink 0'
         params += ' --lowpass %0.3f' % self.maxResolution
 
         # Add extra params is any
@@ -135,19 +133,17 @@ class ProtRelionAutopickLoG(ProtRelionAutopickBase):
         new inserted steps.
         """
         args = [
-                self.getAutopickParams(),
-                self.minDiameter.get(),
-                self.maxDiameter.get(),
-                self.threshold.get()
-            ]
-
-        if self.IS_GT30():
-            args.append(self.threshold2.get())
+            self.getAutopickParams(),
+            self.minDiameter.get(),
+            self.maxDiameter.get(),
+            self.threshold.get(),
+            self.threshold2.get()
+        ]
 
         return args
 
     def _pickMicrographsFromStar(self, micStarFile, cwd, params,
-                                 minDiameter, maxDiameter, threshold, threshold2=None):
+                                 minDiameter, maxDiameter, threshold, threshold2):
         """ Launch the 'relion_autopick' for micrographs in the inputStarFile.
          If the input set of complete, the star file will contain all the
          micrographs. If working in streaming, it will be only one micrograph.
@@ -156,9 +152,7 @@ class ProtRelionAutopickLoG(ProtRelionAutopickBase):
         params += ' --LoG_diam_min %0.3f' % minDiameter
         params += ' --LoG_diam_max %0.3f' % maxDiameter
         params += ' --LoG_adjust_threshold %0.3f' % threshold
-
-        if self.IS_GT30():
-            params += ' --LoG_upper_threshold %0.3f' % threshold2
+        params += ' --LoG_upper_threshold %0.3f' % threshold2
 
         program = self._getProgram('relion_autopick')
 
@@ -184,6 +178,3 @@ class ProtRelionAutopickLoG(ProtRelionAutopickBase):
     def getBoxSize(self):
         """ Return a reasonable box-size in pixels. """
         return self.boxSize.get()
-
-    def IS_GT30(self):
-        return Plugin.IS_GT30()

--- a/relion/protocols/protocol_autopick_log.py
+++ b/relion/protocols/protocol_autopick_log.py
@@ -159,6 +159,10 @@ class ProtRelionAutopickLoG(ProtRelionAutopickBase):
         self.runJob(program, params, cwd=cwd)
 
     # -------------------------- INFO functions --------------------------------
+    def _validate(self):
+        errors = []
+        return errors
+
     def _summary(self):
         summary = []
         return summary

--- a/relion/protocols/protocol_autopick_log.py
+++ b/relion/protocols/protocol_autopick_log.py
@@ -159,20 +159,9 @@ class ProtRelionAutopickLoG(ProtRelionAutopickBase):
         self.runJob(program, params, cwd=cwd)
 
     # -------------------------- INFO functions --------------------------------
-    def _validate(self):
-        errors = []
-        return errors
-
-    def _warnings(self):
-        return []
-
     def _summary(self):
         summary = []
         return summary
-
-    def _methods(self):
-        methodsMsgs = []
-        return methodsMsgs
 
     # -------------------------- UTILS functions -------------------------------
     def getBoxSize(self):

--- a/relion/protocols/protocol_autopick_ref.py
+++ b/relion/protocols/protocol_autopick_ref.py
@@ -382,7 +382,8 @@ class ProtRelion2Autopick(ProtRelionAutopickBase):
         threshold = self.pickingThreshold.get()
         interDist = self.interParticleDistance.get()
         maxStd = self.maxStddevNoise.get()
-        return [basicArgs, threshold, interDist, maxStd]
+        minAvg = self.minAvgNoise.get()
+        return [basicArgs, threshold, interDist, maxStd, minAvg]
 
     def _pickMicrographsFromStar(self, micStarFile, cwd, params,
                                  threshold, minDistance,

--- a/relion/protocols/protocol_autopick_ref.py
+++ b/relion/protocols/protocol_autopick_ref.py
@@ -205,6 +205,17 @@ class ProtRelion2Autopick(ProtRelionAutopickBase):
                             'the feature to eliminate peaks due to high '
                             'background standard deviations.')
 
+        group.addParam('minAvgNoise', params.FloatParam, default=-999,
+                       label='Minimum avg noise:',
+                       help='This is useful to prevent picking in carbon areas,'
+                            ' or areas with big contamination features. Peaks '
+                            'in areas where the background standard deviation '
+                            'in the normalized micrographs is higher than this'
+                            ' value will be ignored. Useful values are '
+                            'probably in the range -0.5 to 0. Set to -999 to '
+                            'switch off the feature to eliminate peaks due to '
+                            'low average background densities.')
+
         group = form.addGroup('Computing')
         group.addParam('shrinkFactor', params.FloatParam, default=0,
                        validators=[params.Range(0, 1, "value should be "
@@ -374,7 +385,8 @@ class ProtRelion2Autopick(ProtRelionAutopickBase):
         return [basicArgs, threshold, interDist, maxStd]
 
     def _pickMicrographsFromStar(self, micStarFile, cwd, params,
-                                 threshold, minDistance, maxStddevNoise):
+                                 threshold, minDistance,
+                                 maxStddevNoise, minAvgNoise):
         """ Launch the 'relion_autopick' for micrographs in the inputStarFile.
          If the input set of complete, the star file will contain all the
          micrographs. If working in streaming, it will be only one micrograph.
@@ -383,6 +395,7 @@ class ProtRelion2Autopick(ProtRelionAutopickBase):
         params += ' --threshold %0.3f' % threshold
         params += ' --min_distance %0.3f' % minDistance
         params += ' --max_stddev_noise %0.3f' % maxStddevNoise
+        params += ' --min_avg_noise %0.3f' % minAvgNoise
 
         program = self._getProgram('relion_autopick')
 

--- a/relion/protocols/protocol_base.py
+++ b/relion/protocols/protocol_base.py
@@ -662,6 +662,11 @@ class ProtRelionBase(EMProtocol):
                                '(i.e. use --pad 1) gives nearly as good results '
                                'as using --pad 2, but some artifacts may appear '
                                'in the corners from signal that is folded back.')
+            form.addParam('skipGridding', BooleanParam, default=True,
+                          label='Skip gridding',
+                          help='If set to Yes, the calculations will '
+                               'skip gridding in the M step to save time, '
+                               'typically with just as good results.')
 
         form.addParam('allParticlesRam', BooleanParam, default=False,
                       label='Pre-read all particles into RAM?',
@@ -1011,11 +1016,13 @@ class ProtRelionBase(EMProtocol):
 
     def _setBasicArgs(self, args):
         """ Return a dictionary with basic arguments. """
-        args['--flatten_solvent'] = ''
         args['--norm'] = ''
         args['--scale'] = ''
         args['--o'] = self._getExtraPath('relion')
         args['--oversampling'] = self.oversampling.get()
+
+        if self.solventFscMask:
+            args['--flatten_solvent'] = ''
 
         if self.IS_CLASSIFY:
             args['--tau2_fudge'] = self.regularisationParamT.get()
@@ -1027,6 +1034,8 @@ class ProtRelionBase(EMProtocol):
         # Padding can be set in a normal run or in a continue
         if self.IS_3D:
             args['--pad'] = 1 if self.skipPadding else 2
+            if self.skipGridding:
+                args['--skip_gridding'] = ''
 
         self._setSamplingArgs(args)
         self._setMaskArgs(args)

--- a/relion/protocols/protocol_bayesian_polishing.py
+++ b/relion/protocols/protocol_bayesian_polishing.py
@@ -372,7 +372,7 @@ class ProtRelionBayesianPolishing(ProtParticles):
                               "larger than the extraction size")
 
         if self.operation == self.OP_TRAIN and self.numberOfMpi > 1:
-                errors.append("Parameter estimation is not supported in MPI mode.")
+            errors.append("Parameter estimation is not supported in MPI mode.")
         return errors
 
     # -------------------------- UTILS functions ------------------------------

--- a/relion/protocols/protocol_ctf_refinement.py
+++ b/relion/protocols/protocol_ctf_refinement.py
@@ -311,7 +311,7 @@ class ProtRelionCtfRefinement(ProtParticles):
                 summary.append("CTF parameter fitting: *Yes*")
                 for p in ['fitPhaseShift', 'fitDefocus', 'fitAstig', 'fitBfactor']:
                     summary.append("   - %s: *%s*" % (self.getParam(p).getLabel(),
-                                                 self.getEnumText(p)))
+                                                      self.getEnumText(p)))
 
             if self.doBeamtiltEstimation:
                 trefoil = '*Yes*' if self.doEstimateTrefoil else 'No'

--- a/relion/protocols/protocol_export_ctf.py
+++ b/relion/protocols/protocol_export_ctf.py
@@ -131,8 +131,8 @@ class ProtRelionExportCtf(EMProtocol):
         micDir = self._getExportPath('Micrographs')
         pwutils.makePath(micDir)
         starWriter = convert.createWriter(rootDir=self._getExportPath(),
-                                    outputDir=micDir,
-                                    useBaseName=True)
+                                          outputDir=micDir,
+                                          useBaseName=True)
         starWriter.writeSetOfMicrographs(micSet, self._getStarFile())
 
     # -------------------------- INFO functions -------------------------------

--- a/relion/protocols/protocol_initialmodel.py
+++ b/relion/protocols/protocol_initialmodel.py
@@ -389,6 +389,8 @@ class ProtRelionInitialModel(ProtInitialVolume, ProtRelionBase):
                      '--oversampling': '1'
                      })
 
+        if self.doFlattenSolvent:
+            args['--flatten_solvent'] = ''
         if not self.doContinue:
             args.update({'--sym': self.symmetryGroup.get()})
 

--- a/relion/tests/test_protocols_relion.py
+++ b/relion/tests/test_protocols_relion.py
@@ -1337,7 +1337,6 @@ class TestRelionExportCtf(TestRelionBase):
                              "There was a problem when importing ctfs.")
         return protCTF
 
-
     def runImportCtffind4(self):
         print(magentaStr("\n==> Importing data - ctfs (from ctffind)"))
         protCTF = self.newProtocol(ProtImportCTF,

--- a/relion/tests/test_protocols_relion.py
+++ b/relion/tests/test_protocols_relion.py
@@ -214,7 +214,6 @@ class TestRelionPicking(TestRelionBase):
             ProtRelion2Autopick,
             inputMicrographs=self.protImportMics.outputMicrographs,
             ctfRelations=protCtf.outputCTF,
-            runType=relion.RUN_COMPUTE,
             inputReferences=protAvg.outputAverages,
             streamingBatchSize=5,
         )

--- a/relion/viewers/viewer_locres.py
+++ b/relion/viewers/viewer_locres.py
@@ -24,9 +24,7 @@
 # *
 # ******************************************************************************
 from pwem.viewers import LocalResolutionViewer
-from pwem.viewers.viewer_chimera import mapVolsWithColorkey
 from pwem.wizards import ColorScaleWizardBase
-from pyworkflow.viewer import ProtocolViewer
 
 from .viewer_base import *
 from ..protocols import ProtRelionLocalRes
@@ -128,4 +126,3 @@ class RelionLocalResViewer(LocalResolutionViewer):
         else:
             imgSlice = volumeData[slice, :, :]
         return imgSlice
-

--- a/relion/viewers/viewer_locres.py
+++ b/relion/viewers/viewer_locres.py
@@ -32,7 +32,6 @@ from .viewer_base import *
 from ..protocols import ProtRelionLocalRes
 
 
-
 class RelionLocalResViewer(LocalResolutionViewer):
     """ Visualization of Relion local resolution results. """
 
@@ -56,7 +55,7 @@ class RelionLocalResViewer(LocalResolutionViewer):
         group.addParam('doShowVolumeSlices', params.LabelParam,
                        label="Show volume slices")
         groupColor.addParam('doShowChimera', params.LabelParam,
-                       label="Show colored map in Chimera", default=True)
+                            label="Show colored map in Chimera", default=True)
 
         _, minRes, maxRes, _ = self.getImgData(self.getResolutionVolumeFileName())
         ColorScaleWizardBase.defineColorScaleParams(groupColor, defaultHighest=maxRes, defaultLowest=minRes)

--- a/relion/wizards.py
+++ b/relion/wizards.py
@@ -163,115 +163,6 @@ class RelionVolFilterWizard(FilterVolumesWizard):
 # PICKING
 # =============================================================================
 
-class Relion2AutopickParams(EmWizard):
-    _targets = [(ProtRelion2Autopick, ['runType',
-                                       'pickingThreshold',
-                                       'interParticleDistance'])]
-
-    def show(self, form):
-        autopickProt = form.protocol
-
-        if not autopickProt.hasAttribute('outputCoordinatesSubset'):
-            form.showWarning("You should run the procotol in 'Optimize' mode "
-                             "at least once before opening the wizard.")
-            return
-
-        project = autopickProt.getProject()
-        micSet = autopickProt.outputMicrographsSubset
-        coordsDir = project.getTmpPath(micSet.getName())
-        pwutils.cleanPath(coordsDir)
-        pwutils.makePath(coordsDir)
-
-        micStarFn = os.path.join(coordsDir, 'micrographs.xmd')
-
-        # Set CTF information to the micrographs to be displayed in the
-        # picking list
-        autopickProt.micDict = OrderedDict()
-        micDict, _ = autopickProt._loadInputList()
-
-        def _preprocessMic(mic, micRow):
-            mic.setCTF(micDict[mic.getMicName()].getCTF())
-
-        writer = convert.createWriter()
-        writer.writeSetOfMicrographs(micSet, micStarFn,
-                                     preprocessImageRow=_preprocessMic)
-
-        # Create a folder in extra to backup the original autopick star files
-        backupDir = autopickProt._getExtraPath('wizard-backup')
-        pwutils.cleanPath(backupDir)
-        pwutils.makePath(backupDir)
-        pwutils.copyPattern(autopickProt._getExtraPath("*autopick.star"),
-                            backupDir)
-
-        cmd = 'emprogram relion_autopick '
-        cmd += '--i input_micrographs.star '
-        cmd += '--threshold %(threshold) --min_distance %(ipd) '
-        cmd += ' --max_stddev_noise %(maxStddevNoise) '
-        cmd += ' --read_fom_maps'
-        cmd += autopickProt.getAutopickParams()
-
-        convertCmd = 'emconvert'
-        convertCmd += ' --coordinates --from relion --to xmipp '
-        convertCmd += ' --input %s' % micSet.getFileName()
-        convertCmd += ' --output %s' % coordsDir
-        convertCmd += ' --extra %s' % autopickProt._getExtraPath()
-
-        args = {
-            "threshold": autopickProt.pickingThreshold,
-            'min_distance': autopickProt.interParticleDistance,
-            'autopickCommand': cmd,
-            'preprocessCommand': 'rm -rf %s/*.pos' % coordsDir,
-            'convertCmd': convertCmd,
-            'protDir': autopickProt.getWorkingDir(),
-            'maxStddevNoise': autopickProt.maxStddevNoise
-        }
-
-        pickerProps = os.path.join(coordsDir, 'picker.conf')
-
-        with open(pickerProps, "w") as f:
-            f.write("""
-            parameters = ipd,threshold,maxStddevNoise
-            ipd.value = %(min_distance)s
-            ipd.label = Inter-particles distance (A)
-            ipd.help = Particles closer together than this distance will be consider to be a single cluster. From each cluster, only one particle will be picked.
-            threshold.value =  %(threshold)s
-            threshold.label = Threshold
-            threshold.help = Use lower thresholds to pick more particles (and more junk probably).
-            maxStddevNoise.value = %(maxStddevNoise)s
-            maxStddevNoise.label = Max. stddev noise
-            maxStddevNoise.help = Prevent picking in carbon areas, useful values probably between 1.0 and 1.2, use -1 to switch it off
-            runDir = %(protDir)s
-            preprocessCommand = %(preprocessCommand)s
-            autopickCommand = %(autopickCommand)s
-            convertCommand = %(convertCmd)s
-            hasInitialCoordinates = true
-            doPickAll = true
-            """ % args)
-        os.environ['XMIPP_EXTRA_ALIASES'] = 'micrograph=rlnMicrographName'
-        process = CoordinatesObjectView(autopickProt.getProject(), micStarFn,
-                                        coordsDir, autopickProt,
-                                        mode=CoordinatesObjectView.MODE_AUTOMATIC,
-                                        pickerProps=pickerProps).show()
-        process.wait()
-        myprops = pwutils.readProperties(pickerProps)
-
-        # Check if the wizard changes were accepted or just canceled
-        if myprops.get('applyChanges', 'false') == 'true':
-            form.setVar('pickingThreshold', myprops['threshold.value'])
-            form.setVar('interParticleDistance', myprops['ipd.value'])
-            form.setVar('maxStddevNoise', myprops['maxStddevNoise.value'])
-            # Change the run type now to 'Compute' after using the wizard
-            # and (supposedly) optimized parameters
-            form.setVar('runType', RUN_COMPUTE)
-            # Mark the wizard was used
-            setattr(autopickProt, 'wizardExecuted', True)
-        else:
-            # If the wizard was not execute, we should restore the original
-            # autopick star files in case their were modified by the wizard
-            pwutils.copyPattern(os.path.join(backupDir, "*autopick.star"),
-                                autopickProt._getExtraPath())
-
-
 class Relion2PartDiameter(RelionPartMaskDiameterWizard):
     _targets = [(ProtRelion2Autopick, ['particleDiameter'])]
 
@@ -295,74 +186,73 @@ class Relion2PartDiameter(RelionPartMaskDiameterWizard):
 class RelionWizLogPickParams(EmWizard):
     params = ['minDiameter',
               'maxDiameter',
-              'threshold']
-
-    if Plugin.IS_GT30():
-        params.append('threshold2')
+              'threshold',
+              'threshold2']
 
     _targets = [(ProtRelionAutopickLoG, params)]
 
     def show(self, form):
-        autopickProt = form.protocol
-        project = autopickProt.getProject()
-        micSet = autopickProt.getInputMicrographs()
+        prot = form.protocol
+        project = prot.getProject()
+        micSet = prot.getInputMicrographs()
+
+        if not micSet:
+            form.showWarning("You should select input micrographs "
+                             "before opening the wizard.")
+
+        params, minDiameter, maxDiameter, threshold, threshold2 = prot._getPickArgs()
+
         micfn = micSet.getFileName()
         coordsDir = project.getTmpPath(micSet.getName())
-        print("coordsDir: ", coordsDir)
-
-        if Plugin.IS_GT30():
-            params, minDiameter, maxDiameter, threshold, threshold2 = autopickProt._getPickArgs()
-        else:
-            params, minDiameter, maxDiameter, threshold = autopickProt._getPickArgs()
-
         pwutils.cleanPath(coordsDir)
         pwutils.makePath(coordsDir)
+
         pickerProps = os.path.join(coordsDir, 'picker.conf')
         micStarFn = os.path.join(coordsDir, 'input_micrographs.star')
 
         writer = convert.createWriter(rootDir=coordsDir,
-                                outputDir=coordsDir)
+                                      outputDir=coordsDir)
         writer.writeSetOfMicrographs(micSet, micStarFn)
 
-        # params = params.replace('--odir ""', '--odir extra')
         autopickCmd = "emprogram relion_autopick "
         autopickCmd += ' --i input_micrographs.star '
         autopickCmd += params
         autopickCmd += ' --LoG_diam_min %(mind) '
         autopickCmd += ' --LoG_diam_max %(maxd) '
         autopickCmd += ' --LoG_adjust_threshold %(threshold) '
+        autopickCmd += ' --LoG_upper_threshold %(threshold2) '
 
         args = {
-            "convert": 'emconvert',
+            "convertCmd": 'emconvert',
             'coordsDir': coordsDir,
             'micsSqlite': micSet.getFileName(),
             "minDiameter": minDiameter,
             "maxDiameter": maxDiameter,
             "threshold": threshold,
-            'projDir': project.getPath(),
+            "threshold2": threshold2,
             "autopickCmd": autopickCmd
         }
 
         with open(pickerProps, "w") as f:
             f.write("""
-            parameters = mind,maxd,threshold
+            parameters = mind,maxd,threshold,threshold2
             mind.value = %(minDiameter)s
             mind.label = Min diam.(A)
             mind.help = The smallest allowed diameter for the blob-detection algorithm. This should correspond to the smallest size of your particles in Angstroms.
             maxd.value = %(maxDiameter)s
             maxd.label = Max diam.(A)
             maxd.help = The largest allowed diameter for the blob-detection algorithm. This should correspond to the largest size of your particles in Angstroms.
-            threshold.value =  %(threshold)s
-            threshold.label = Threshold
-            threshold.help = Lower threshold -> more particles
+            threshold.value = %(threshold)s
+            threshold.label = Min threshold
+            threshold2.value = %(threshold2)s
+            threshold2.label = Max threshold
             runDir = %(coordsDir)s
             autopickCommand = %(autopickCmd)s
-            convertCommand = %(convert)s --coordinates --from relion --to xmipp --input %(micsSqlite)s --output %(coordsDir)s --extra %(coordsDir)s/
+            convertCommand = %(convertCmd)s --coordinates --from relion --to xmipp --input %(micsSqlite)s --output %(coordsDir)s --extra %(coordsDir)s/
             hasInitialCoordinates = false
             doPickAll = true
             """ % args)
-        process = CoordinatesObjectView(autopickProt.getProject(), micfn,
-                                        coordsDir, autopickProt,
+        process = CoordinatesObjectView(project, micfn, coordsDir, prot,
                                         mode=CoordinatesObjectView.MODE_AUTOMATIC,
                                         pickerProps=pickerProps).show()
         process.wait()
@@ -372,6 +262,7 @@ class RelionWizLogPickParams(EmWizard):
             form.setVar('minDiameter', myprops['mind.value'])
             form.setVar('maxDiameter', myprops['maxd.value'])
             form.setVar('threshold', myprops['threshold.value'])
+            form.setVar('threshold2', myprops['threshold2.value'])
 
 
 class RelionWizMtfSelector(EmWizard):


### PR DESCRIPTION
- remove ref picker wizard
- remove optimize mode for refpicker
- fix logpicker wizard (close #215)
- fix --odir param

Optimize mode, imho, is not very useful since autopicking on a few mics is very fast (both Log/Ref pickers) without any complicated code dealing with the FOM maps.