### PR TITLE
relion crashes if NO  alignment and  'consider alignment as priors' a…

### DIFF
--- a/relion/protocols/protocol_base.py
+++ b/relion/protocols/protocol_base.py
@@ -862,6 +862,10 @@ class ProtRelionBase(EMProtocol):
                     errors.append('If you want to do only classification without '
                                   'alignment, then you should use the option: \n'
                                   '*Consider previous alignment?* = Yes')
+                if self.alignmentAsPriors:
+                    errors.append('When only doing classification (no alignment) '
+                                  " option 'consider alignment as priors' cannot"
+                                  " be enabled.")
 
         return errors
 


### PR DESCRIPTION
…re selected

relion crashes if NO  alignment and  'consider alignment as priors' are selected. So add and extra check to validate in order to avoid this problem
 
```            if not self.doImageAlignment:
              if self.alignmentAsPriors:
                    errors.append('When only doing classification (no alignment) '
                                  " option 'consider alignment as priors' cannot"
                                  " be enabled.")
```