### PR TITLE
release 3.1.1

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,4 +1,4 @@
-3.1.1 - fixed the bug causing wrong shifts saved by expand symmetry, init model and subtract protocols
+3.1.1 - fixed the bug causing wrong shifts saved by init model and subtract protocols
 3.1:
     - initial EER support for motion correction and polishing, not available yet
     - consider hot pixels from relion mc for polishing

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,4 +1,4 @@
-3.1.1 - minor changes
+3.1.1 - fixed the bug causing wrong shifts saved by expand symmetry, init model and subtract protocols
 3.1:
     - initial EER support for motion correction and polishing, not available yet
     - consider hot pixels from relion mc for polishing

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,3 +1,4 @@
+3.1.1 - minor changes
 3.1:
     - initial EER support for motion correction and polishing, not available yet
     - consider hot pixels from relion mc for polishing

--- a/relion/__init__.py
+++ b/relion/__init__.py
@@ -31,7 +31,7 @@ import pwem
 
 from .constants import *
 
-__version__ = '3.1'
+__version__ = '3.1.1'
 _logo = "relion_logo.jpg"
 _references = ['Scheres2012a', 'Scheres2012b', 'Kimanius2016', 'Zivanov2018']
 

--- a/relion/convert/__init__.py
+++ b/relion/convert/__init__.py
@@ -53,12 +53,8 @@ def createReader(**kwargs):
 def createWriter(**kwargs):
     """ Create a new Writer instance.
     By default it will create the new version (3.1 or newer) of STAR file.
-    It can also be forced to use old format by passing the format='30' argument
     """
-    is30 = kwargs.get('format', '') == '30'
-    Writer = convert30.Writer if is30 else convert31.Writer
-
-    return Writer(**kwargs)
+    return convert31.Writer(**kwargs)
 
 
 def writeSetOfParticles(imgSet, starFile, **kwargs):
@@ -75,8 +71,6 @@ def writeSetOfParticles(imgSet, starFile, **kwargs):
         alignType:
         extraLabels:
         postprocessImageRow:
-        format: string value to specify STAR format, if '30' it will use
-            Relion3.0 format
     """
     return createWriter(**kwargs).writeSetOfParticles(imgSet, starFile, **kwargs)
 

--- a/relion/convert/convert_deprecated.py
+++ b/relion/convert/convert_deprecated.py
@@ -507,38 +507,6 @@ def writeSetOfImages(imgSet, filename, imgToFunc,
     mdFn.write('%s@%s' % (blockName, filename))
 
 
-def _writeSetOfParticles(imgSet, starFile, **kwargs):
-    """ This function will write a SetOfImages as Relion meta
-    Params:
-        imgSet: the SetOfImages instance.
-        starFile: the filename where to write the meta
-        filesMapping: this dict will help when there is need to replace images names
-    """
-    outputDir = kwargs.get('outputDir', None)
-
-    if outputDir is not None:
-        filesDict = convertBinaryFiles(imgSet, outputDir)
-        kwargs['filesDict'] = filesDict
-    partMd = md.MetaData()
-    setOfImagesToMd(imgSet, partMd, particleToRow, **kwargs)
-
-    if kwargs.get('fillMagnification', False):
-        pixelSize = imgSet.getSamplingRate()
-        mag = imgSet.getAcquisition().getMagnification()
-        detectorPxSize = mag * pixelSize / 10000
-
-        partMd.fillConstant(md.RLN_CTF_MAGNIFICATION, mag)
-        partMd.fillConstant(md.RLN_CTF_DETECTOR_PIXEL_SIZE, detectorPxSize)
-    else:
-        # Remove Magnification from metadata to avoid wrong values of pixel size.
-        # In Relion if Magnification and DetectorPixelSize are in metadata,
-        # pixel size is ignored in the command line.
-        partMd.removeLabel(md.RLN_CTF_MAGNIFICATION)
-
-    blockName = kwargs.get('blockName', 'Particles')
-    partMd.write('%s@%s' % (blockName, starFile))
-
-
 def writeSetOfVolumes(volSet, filename, blockName='Volumes', **kwargs):
     writeSetOfImages(volSet, filename, volumeToRow, blockName, **kwargs)
 
@@ -590,33 +558,6 @@ def writeReferences(inputSet, outputRoot, useBasename=False, **kwargs):
     refsMd.write(starFile)
 
 
-def micrographToRow(mic, micRow, **kwargs):
-    """ Set labels values from Micrograph mic to md row. """
-    imageToRow(mic, micRow, imgLabel=md.RLN_MICROGRAPH_NAME, **kwargs)
-
-
-def movieToRow(movie, movieRow, **kwargs):
-    """ Set labels values from movie to md row. """
-    imageToRow(movie, movieRow, imgLabel=md.RLN_MICROGRAPH_MOVIE_NAME, **kwargs)
-
-
-def writeSetOfMicrographs(micSet, starFile, **kwargs):
-    """ If 'outputDir' is in kwargs, the micrographs are
-    converted or linked in the outputDir.
-    """
-    micMd = md.MetaData()
-    setOfImagesToMd(micSet, micMd, micrographToRow, **kwargs)
-    blockName = kwargs.get('blockName', 'Particles')
-    micMd.write('%s@%s' % (blockName, starFile))
-
-
-def writeSetOfMovies(movieSet, starFile, **kwargs):
-    movieMd = md.MetaData()
-    setOfImagesToMd(movieSet, movieMd, movieToRow, **kwargs)
-    blockName = kwargs.get('blockName', '')
-    movieMd.write('%s@%s' % (blockName, starFile))
-
-
 def copyOrLinkFileName(imgRow, prefixDir, outputDir, copyFiles=False):
     index, imgPath = relionToLocation(imgRow.get(md.RLN_IMAGE_NAME))
     baseName = os.path.basename(imgPath)
@@ -649,5 +590,3 @@ def setupCTF(imgRow, sampling):
                        imgRow.get(md.MDL_CTF_DEFOCUSU))
         if not hasDefocusAngle:
             imgRow.set(md.MDL_CTF_DEFOCUS_ANGLE, 0.)
-
-

--- a/relion/protocols/protocol_assign_optic_groups.py
+++ b/relion/protocols/protocol_assign_optic_groups.py
@@ -23,11 +23,13 @@
 # *  e-mail address 'scipion@cnb.csic.es'
 # *
 # **************************************************************************
+
 import os
 import emtable
 
 from pyworkflow.object import Integer
 import pyworkflow.utils as pwutils
+from pyworkflow.constants import PROD
 import pyworkflow.protocol.params as params
 from pwem.objects import SetOfMovies, SetOfParticles, SetOfMicrographs
 
@@ -40,6 +42,7 @@ class ProtRelionAssignOpticsGroup(ProtRelionBase):
      Input set can be: movies, micrographs or particles.
     """
     _label = 'assign optics groups'
+    _devStatus = PROD
     
     # --------------------------- DEFINE param functions ----------------------
     def _defineParams(self, form):

--- a/relion/protocols/protocol_autopick_log.py
+++ b/relion/protocols/protocol_autopick_log.py
@@ -27,6 +27,7 @@
 from os.path import relpath
 
 import pyworkflow.protocol.params as params
+from pyworkflow.constants import PROD
 from pyworkflow.protocol import STEPS_SERIAL
 from pwem.protocols import ProtParticlePickingAuto
 
@@ -39,6 +40,7 @@ class ProtRelionAutopickLoG(ProtRelionAutopickBase):
     Laplacian of Gaussian (LoG) option.
     """
     _label = 'auto-picking LoG'
+    _devStatus = PROD
 
     def __init__(self, **kwargs):
         ProtParticlePickingAuto.__init__(self, **kwargs)

--- a/relion/protocols/protocol_autopick_ref.py
+++ b/relion/protocols/protocol_autopick_ref.py
@@ -32,6 +32,7 @@ from pwem.constants import RELATION_CTF
 from pwem.emlib.image import ImageHandler
 from pyworkflow.utils.properties import Message
 import pyworkflow.utils as pwutils
+from pyworkflow.constants import PROD
 
 import relion.convert
 from ..constants import *
@@ -47,6 +48,7 @@ class ProtRelion2Autopick(ProtRelionAutopickBase):
     The wrapper implementation does not read/write any FOM maps compared to Relion
     """
     _label = 'auto-picking'
+    _devStatus = PROD
 
     # -------------------------- DEFINE param functions ------------------------
     def _defineParams(self, form):

--- a/relion/protocols/protocol_bayesian_polishing.py
+++ b/relion/protocols/protocol_bayesian_polishing.py
@@ -32,6 +32,7 @@ from emtable import Table
 
 import pyworkflow.utils as pwutils
 import pyworkflow.protocol.params as params
+from pyworkflow.constants import PROD
 from pwem.protocols import ProtParticles
 import pwem.emlib.metadata as md
 from pwem.constants import ALIGN_PROJ
@@ -59,6 +60,7 @@ class ProtRelionBayesianPolishing(ProtParticles):
     """
 
     _label = 'bayesian polishing'
+    _devStatus = PROD
 
     OP_TRAIN = 0
     OP_POLISH = 1

--- a/relion/protocols/protocol_center_averages.py
+++ b/relion/protocols/protocol_center_averages.py
@@ -26,6 +26,7 @@
 
 from pwem.protocols import ProtProcessParticles
 from pyworkflow.protocol.params import PointerParam
+from pyworkflow.constants import PROD
 
 from .protocol_base import ProtRelionBase
 
@@ -36,6 +37,7 @@ class ProtRelionCenterAverages(ProtProcessParticles, ProtRelionBase):
      (With *--shift_com* option)
     """
     _label = 'center averages'
+    _devStatus = PROD
     
     # --------------------------- DEFINE param functions ----------------------
     def _defineParams(self, form):

--- a/relion/protocols/protocol_classify2d.py
+++ b/relion/protocols/protocol_classify2d.py
@@ -23,6 +23,8 @@
 # *  e-mail address 'scipion@cnb.csic.es'
 # *
 # **************************************************************************
+
+from pyworkflow.constants import PROD
 from pwem.constants import ALIGN_2D
 from pwem.objects import SetOfClasses2D
 from pwem.protocols import ProtClassify2D
@@ -35,6 +37,7 @@ class ProtRelionClassify2D(ProtRelionBase, ProtClassify2D):
     """ This protocol runs Relion 2D classification."""
 
     _label = '2D classification'
+    _devStatus = PROD
     IS_2D = True
     OUTPUT_TYPE = SetOfClasses2D
     

--- a/relion/protocols/protocol_classify3d.py
+++ b/relion/protocols/protocol_classify3d.py
@@ -25,6 +25,7 @@
 # **************************************************************************
 from emtable import Table
 
+from pyworkflow.constants import PROD
 from pwem.constants import ALIGN_PROJ
 from pwem.protocols import ProtClassify3D
 
@@ -42,6 +43,7 @@ class ProtRelionClassify3D(ProtClassify3D, ProtRelionBase):
     """
 
     _label = '3D classification'
+    _devStatus = PROD
     CHANGE_LABELS = ['rlnChangesOptimalOrientations',
                      'rlnChangesOptimalOffsets',
                      'rlnOverallAccuracyRotations',

--- a/relion/protocols/protocol_compress_estimate_gain.py
+++ b/relion/protocols/protocol_compress_estimate_gain.py
@@ -27,7 +27,7 @@
 import pyworkflow.protocol.params as params
 import pyworkflow.utils as pwutils
 from pyworkflow.protocol import STEPS_SERIAL
-from pyworkflow.constants import VERSION_3_0
+from pyworkflow.constants import PROD
 from pwem.protocols import ProtProcessMovies
 
 import relion
@@ -39,8 +39,8 @@ class ProtRelionCompressEstimateGain(ProtProcessMovies):
     Using *relion_convert_to_tiff* to estimate the gain that can be used
     for better compression.
     """
-    _lastUpdateVersion = VERSION_3_0
     _label = 'estimate gain to compress'
+    _devStatus = PROD
 
     def __init__(self, **kwargs):
         ProtProcessMovies.__init__(self, **kwargs)

--- a/relion/protocols/protocol_compress_movies.py
+++ b/relion/protocols/protocol_compress_movies.py
@@ -28,7 +28,7 @@ import os
 
 import pyworkflow.protocol.params as params
 import pyworkflow.utils as pwutils
-from pyworkflow.constants import VERSION_3_0
+from pyworkflow.constants import PROD
 from pwem.protocols import ProtAlignMovies
 from pwem.objects import MovieAlignment
 from pyworkflow.protocol import STEPS_PARALLEL
@@ -40,8 +40,8 @@ class ProtRelionCompressMovies(ProtAlignMovies):
     """
     Using *relion_convert_to_tiff* to compress a set of movies.
     """
-    _lastUpdateVersion = VERSION_3_0
     _label = 'compress movies'
+    _devStatus = PROD
 
     OP_COMPRESS = 0
     OP_ESTIMATE = 1

--- a/relion/protocols/protocol_create_mask3d.py
+++ b/relion/protocols/protocol_create_mask3d.py
@@ -27,6 +27,7 @@
 import math
 
 import pyworkflow.protocol.params as params
+from pyworkflow.constants import PROD
 from pwem.protocols import ProtCreateMask3D
 from pwem.objects import VolumeMask
 
@@ -39,6 +40,7 @@ class ProtRelionCreateMask3D(ProtCreateMask3D):
     The mask is created from a 3d volume or by comparing two input volumes.
     """
     _label = 'create 3d mask'
+    _devStatus = PROD
 
     # --------------------------- DEFINE param functions ----------------------
     def _defineParams(self, form):

--- a/relion/protocols/protocol_crop_resize.py
+++ b/relion/protocols/protocol_crop_resize.py
@@ -26,6 +26,7 @@
 
 import pyworkflow.protocol.params as params
 import pyworkflow.utils as pwutils
+from pyworkflow.constants import PROD
 from pwem.protocols import ProtPreprocessVolumes
 from pwem.emlib.image import ImageHandler
 from pwem.objects import Volume
@@ -33,7 +34,9 @@ from pwem.objects import Volume
 
 class ProtRelionResizeVolume(ProtPreprocessVolumes):
     """ This protocol rescales/resizes 3D volumes using relion_image_handler. """
+
     _label = 'crop/resize volumes'
+    _devStatus = PROD
 
     def __init__(self, **kwargs):
         ProtPreprocessVolumes.__init__(self, **kwargs)

--- a/relion/protocols/protocol_ctf_refinement.py
+++ b/relion/protocols/protocol_ctf_refinement.py
@@ -26,6 +26,7 @@
 
 import pyworkflow.utils as pwutils
 import pyworkflow.protocol.params as params
+from pyworkflow.constants import PROD
 from pwem.constants import ALIGN_PROJ
 from pwem.protocols import ProtParticles
 
@@ -39,6 +40,7 @@ from ..objects import CtfRefineGlobalInfo
 class ProtRelionCtfRefinement(ProtParticles):
     """ Wrapper protocol for the Relion's CTF refinement. """
     _label = 'ctf refinement'
+    _devStatus = PROD
 
     def _initialize(self):
         self._createFilenameTemplates()

--- a/relion/protocols/protocol_expand_symmetry.py
+++ b/relion/protocols/protocol_expand_symmetry.py
@@ -26,6 +26,7 @@
 from emtable import Table
 
 from pyworkflow.protocol.params import StringParam
+from pyworkflow.constants import PROD
 from pyworkflow.object import String
 from pwem.constants import ALIGN_PROJ
 from pwem.protocols import ProtProcessParticles
@@ -40,6 +41,7 @@ class ProtRelionExpandSymmetry(ProtProcessParticles):
     expand the set by applying a pseudo-symmetry.
     """
     _label = 'expand symmetry'
+    _devStatus = PROD
 
     # -------------------------- DEFINE param functions -----------------------
     def _defineProcessParams(self, form):

--- a/relion/protocols/protocol_expand_symmetry.py
+++ b/relion/protocols/protocol_expand_symmetry.py
@@ -88,7 +88,8 @@ class ProtRelionExpandSymmetry(ProtProcessParticles):
             mdOut.writeStar(f, tableName='particles')
             mdOptics.writeStar(f, tableName='optics')
 
-        reader = convert.createReader()
+        px = imgSet.getSamplingRate()
+        reader = convert.createReader(pixelSize=px)
         reader.readSetOfParticles(
             outImagesMd, partSet,
             alignType=ALIGN_PROJ,

--- a/relion/protocols/protocol_expand_symmetry.py
+++ b/relion/protocols/protocol_expand_symmetry.py
@@ -88,8 +88,7 @@ class ProtRelionExpandSymmetry(ProtProcessParticles):
             mdOut.writeStar(f, tableName='particles')
             mdOptics.writeStar(f, tableName='optics')
 
-        px = imgSet.getSamplingRate()
-        reader = convert.createReader(pixelSize=px)
+        reader = convert.createReader()
         reader.readSetOfParticles(
             outImagesMd, partSet,
             alignType=ALIGN_PROJ,

--- a/relion/protocols/protocol_export_coords.py
+++ b/relion/protocols/protocol_export_coords.py
@@ -28,7 +28,7 @@ import os
 
 import pyworkflow.protocol.params as params
 import pyworkflow.utils as pwutils
-from pyworkflow.constants import VERSION_3_0
+from pyworkflow.constants import PROD
 
 import relion.convert as convert
 from .protocol_base import ProtRelionBase
@@ -37,8 +37,8 @@ from .protocol_base import ProtRelionBase
 class ProtRelionExportCoordinates(ProtRelionBase):
     """ Export coordinates from Relion to be used outside Scipion. """
 
-    _lastUpdateVersion = VERSION_3_0
     _label = 'export coordinates'
+    _devStatus = PROD
 
     # --------------------------- DEFINE param functions ----------------------
     def _defineParams(self, form):

--- a/relion/protocols/protocol_export_ctf.py
+++ b/relion/protocols/protocol_export_ctf.py
@@ -28,6 +28,7 @@ import os
 
 from pwem.objects import SetOfMicrographs
 from pwem.protocols import EMProtocol
+from pyworkflow.constants import PROD
 import pyworkflow.utils as pwutils
 import pyworkflow.protocol.params as params
 
@@ -38,6 +39,7 @@ class ProtRelionExportCtf(EMProtocol):
     """ Export a SetOfCTF to a Relion STAR file. """
 
     _label = 'export ctf'
+    _devStatus = PROD
     CTF_STAR_FILE = 'micrographs_ctf_%06d.star'
 
     # -------------------------- DEFINE param functions -----------------------

--- a/relion/protocols/protocol_export_particles.py
+++ b/relion/protocols/protocol_export_particles.py
@@ -28,6 +28,7 @@ import os
 
 import pyworkflow.protocol.params as params
 import pyworkflow.utils as pwutils
+from pyworkflow.constants import PROD
 from pwem.constants import ALIGN_NONE
 from pwem.emlib.image import ImageHandler
 from pwem.protocols import ProtProcessParticles
@@ -41,6 +42,7 @@ class ProtRelionExportParticles(ProtProcessParticles, ProtRelionBase):
     """ Export particles from Relion to be used outside Scipion. """
 
     _label = 'export particles'
+    _devStatus = PROD
     PTCLS_STAR_FILE = 'particles_%06d.star'
     
     # --------------------------- DEFINE param functions ----------------------

--- a/relion/protocols/protocol_extract_particles.py
+++ b/relion/protocols/protocol_extract_particles.py
@@ -30,6 +30,7 @@ from pyworkflow.object import Set, Integer
 import pyworkflow.utils as pwutils
 from pyworkflow.protocol.constants import STATUS_FINISHED
 import pyworkflow.protocol.params as params
+from pyworkflow.constants import PROD
 
 from pwem.protocols import ProtExtractParticles
 from pwem.emlib.image import ImageHandler
@@ -45,6 +46,7 @@ class ProtRelionExtractParticles(ProtExtractParticles, ProtRelionBase):
     """ Protocol to extract particles using a set of coordinates. """
 
     _label = 'particles extraction'
+    _devStatus = PROD
 
     def __init__(self, **kwargs):
         ProtExtractParticles.__init__(self, **kwargs)

--- a/relion/protocols/protocol_gentle_clean.py
+++ b/relion/protocols/protocol_gentle_clean.py
@@ -29,6 +29,7 @@ import re
 from glob import glob
 
 from pyworkflow.protocol import Protocol
+from pyworkflow.constants import BETA
 from pyworkflow.protocol.params import LabelParam
 
 
@@ -37,6 +38,7 @@ class ProtRelionCleanJobs(Protocol):
     Run Relion gentle clean procedure for the whole project.
     """
     _label = 'clean project'
+    _devStatus = BETA
 
     def __init__(self, **kwargs):
         Protocol.__init__(self, **kwargs)

--- a/relion/protocols/protocol_initialmodel.py
+++ b/relion/protocols/protocol_initialmodel.py
@@ -442,7 +442,9 @@ class ProtRelionInitialModel(ProtInitialVolume, ProtRelionBase):
     def _fillDataFromIter(self, imgSet, iteration):
         outImgsFn = self._getFileName('data', iter=iteration)
         imgSet.setAlignmentProj()
-        self.reader = convert.createReader(alignType=ALIGN_PROJ)
+        px = imgSet.getSamplingRate()
+        self.reader = convert.createReader(alignType=ALIGN_PROJ,
+                                           pixelSize=px)
         mdIter = convert.Table.iterRows('particles@' + outImgsFn, key='rlnImageId')
         imgSet.copyItems(self._getInputParticles(), doClone=False,
                          updateItemCallback=self._createItemMatrix,

--- a/relion/protocols/protocol_initialmodel.py
+++ b/relion/protocols/protocol_initialmodel.py
@@ -30,6 +30,7 @@ from emtable import Table
 from pwem.constants import ALIGN_PROJ
 from pwem.protocols import ProtInitialVolume
 from pwem.objects import Volume
+from pyworkflow.constants import PROD
 from pyworkflow.protocol.params import (PointerParam, FloatParam,
                                         LabelParam, IntParam,
                                         EnumParam, StringParam,
@@ -48,6 +49,7 @@ class ProtRelionInitialModel(ProtInitialVolume, ProtRelionBase):
     Relion Stochastic Gradient Descent (SGD) algorithm.
     """
     _label = '3D initial model'
+    _devStatus = PROD
     IS_CLASSIFY = False
     IS_3D_INIT = True
     IS_2D = False

--- a/relion/protocols/protocol_localres.py
+++ b/relion/protocols/protocol_localres.py
@@ -29,6 +29,7 @@
 from pwem.emlib.image import ImageHandler
 import pyworkflow.utils as pwutils
 import pyworkflow.protocol.params as params
+from pyworkflow.constants import PROD
 
 import relion
 import relion.convert
@@ -44,6 +45,7 @@ class ProtRelionLocalRes(ProtRelionPostprocess):
     of that mask.
     """
     _label = 'local resolution'
+    _devStatus = PROD
 
     def _createFilenameTemplates(self):
         """ Centralize how files are called for iterations and references. """

--- a/relion/protocols/protocol_motioncor.py
+++ b/relion/protocols/protocol_motioncor.py
@@ -34,6 +34,7 @@ import emtable as md
 import pyworkflow.object as pwobj
 import pyworkflow.protocol.params as params
 import pyworkflow.protocol.constants as cons
+from pyworkflow.constants import PROD
 import pyworkflow.utils as pwutils
 from pwem.protocols import ProtAlignMovies
 from pwem.objects import Image
@@ -49,6 +50,7 @@ class ProtRelionMotioncor(ProtAlignMovies):
     """ Wrapper for the Relion's implementation of motioncor algorithm. """
 
     _label = 'motion correction'
+    _devStatus = PROD
 
     def __init__(self, **kwargs):
         ProtAlignMovies.__init__(self, **kwargs)

--- a/relion/protocols/protocol_multibody.py
+++ b/relion/protocols/protocol_multibody.py
@@ -29,6 +29,7 @@ from emtable import Table
 
 import pyworkflow.utils as pwutils
 import pyworkflow.protocol.params as params
+from pyworkflow.constants import PROD
 from pwem.objects import Volume, Float
 from pwem.protocols import ProtAnalysis3D
 
@@ -52,6 +53,7 @@ class ProtRelionMultiBody(ProtAnalysis3D, ProtRelionBase):
     the most important motions in the data.
     """
     _label = '3D multi-body'
+    _devStatus = PROD
 
     def _getInputPath(self, *paths):
         return self._getPath('input', *paths)

--- a/relion/protocols/protocol_postprocess.py
+++ b/relion/protocols/protocol_postprocess.py
@@ -31,6 +31,7 @@ from emtable import Table
 
 import pyworkflow.utils as pwutils
 import pyworkflow.protocol.params as params
+from pyworkflow.constants import PROD
 from pwem.protocols import ProtAnalysis3D
 from pwem.emlib.image import ImageHandler
 from pwem.objects import Volume
@@ -44,6 +45,7 @@ class ProtRelionPostprocess(ProtAnalysis3D):
     overfitting estimation, MTF-correction and B-factor sharpening.
     """
     _label = 'post-processing'
+    _devStatus = PROD
 
     def _getInputPath(self, *paths):
         return self._getPath('input', *paths)

--- a/relion/protocols/protocol_preprocess.py
+++ b/relion/protocols/protocol_preprocess.py
@@ -28,6 +28,7 @@ import pyworkflow.utils as pwutils
 from pyworkflow.protocol.params import (PointerParam, BooleanParam,
                                         FloatParam, IntParam, Positive)
 from pyworkflow.protocol import STEPS_PARALLEL
+from pyworkflow.constants import PROD
 from pwem.constants import NO_INDEX
 from pwem.objects import SetOfAverages
 from pwem.protocols import ProtProcessParticles
@@ -43,6 +44,7 @@ class ProtRelionPreprocessParticles(ProtProcessParticles, ProtRelionBase):
     the particles.
     """
     _label = 'preprocess particles'
+    _devStatus = PROD
     
     def __init__(self, **args):
         ProtProcessParticles.__init__(self, **args)

--- a/relion/protocols/protocol_reconstruct.py
+++ b/relion/protocols/protocol_reconstruct.py
@@ -27,6 +27,7 @@
 from pyworkflow.protocol.params import (PointerParam, FloatParam,  
                                         StringParam, BooleanParam,
                                         EnumParam, IntParam, LEVEL_ADVANCED)
+from pyworkflow.constants import PROD
 from pwem.objects import Volume
 from pwem.protocols import ProtReconstruct3D
 from pwem.constants import ALIGN_PROJ
@@ -42,6 +43,7 @@ class ProtRelionReconstruct(ProtReconstruct3D):
     and used as direction projections to reconstruct.
     """
     _label = 'reconstruct'
+    _devStatus = PROD
 
     # -------------------------- DEFINE param functions -----------------------
     def _defineParams(self, form):

--- a/relion/protocols/protocol_refine3d.py
+++ b/relion/protocols/protocol_refine3d.py
@@ -25,6 +25,7 @@
 # **************************************************************************
 from emtable import Table
 
+from pyworkflow.constants import PROD
 from pwem.constants import ALIGN_PROJ
 from pwem.objects import Volume, FSC
 from pwem.protocols import ProtRefine3D
@@ -44,6 +45,7 @@ parameters of a statistical model are learned from the data,which
 leads to objective and high-quality results.
     """    
     _label = '3D auto-refine'
+    _devStatus = PROD
     IS_CLASSIFY = False
     CHANGE_LABELS = ['rlnChangesOptimalOrientations',
                      'rlnChangesOptimalOffsets',

--- a/relion/protocols/protocol_remove_views.py
+++ b/relion/protocols/protocol_remove_views.py
@@ -28,7 +28,7 @@ import numpy as np
 from random import sample
 
 import pyworkflow.protocol.params as params
-from pyworkflow.constants import VERSION_3_0
+from pyworkflow.constants import PROD
 from pwem.protocols import ProtParticles
 import pwem.convert.transformations as tfs
 
@@ -39,8 +39,8 @@ class ProtRelionRemovePrefViews(ProtParticles):
     Inspired by https://github.com/leschzinerlab/Relion
 
     """
-    _lastUpdateVersion = VERSION_3_0
     _label = 'remove preferential views'
+    _devStatus = PROD
 
     def _defineParams(self, form):
         form.addSection(label='Input')

--- a/relion/protocols/protocol_subtract.py
+++ b/relion/protocols/protocol_subtract.py
@@ -252,7 +252,9 @@ class ProtRelionSubtract(ProtOperateParticles):
         outImgSet.copyInfo(imgSet)
         outImgSet.setAlignmentProj()
 
-        self.reader = convert.createReader(alignType=ALIGN_PROJ)
+        px = imgSet.getSamplingRate()
+        self.reader = convert.createReader(alignType=ALIGN_PROJ,
+                                           pixelSize=px)
         mdIter = convert.Table.iterRows('particles@' + outImgsFn)
         outImgSet.copyItems(imgSet, doClone=False,
                             updateItemCallback=self._updateItem,

--- a/relion/protocols/protocol_subtract.py
+++ b/relion/protocols/protocol_subtract.py
@@ -25,6 +25,7 @@
 # **************************************************************************
 
 from pyworkflow.object import String, Integer
+from pyworkflow.constants import PROD
 from pyworkflow.protocol.params import (PointerParam, BooleanParam,
                                         IntParam, LabelParam)
 from pwem.constants import ALIGN_PROJ
@@ -41,6 +42,7 @@ class ProtRelionSubtract(ProtOperateParticles):
     properly generate volume projections.
     """
     _label = 'subtract projection'
+    _devStatus = PROD
 
     def _initialize(self):
         self._createFilenameTemplates()

--- a/relion/protocols/protocol_symmetrize_volume.py
+++ b/relion/protocols/protocol_symmetrize_volume.py
@@ -25,6 +25,7 @@
 # **************************************************************************
 
 import pyworkflow.protocol.params as params
+from pyworkflow.constants import PROD
 from pwem.objects import Volume
 from pwem.emlib.image import ImageHandler
 from pwem.protocols import ProtAlignVolume
@@ -36,6 +37,7 @@ class ProtRelionSymmetrizeVolume(ProtAlignVolume):
         *relion_align_symmetry* and *relion_image_handler*.
     """
     _label = 'symmetrize volume'
+    _devStatus = PROD
     
     # --------------------------- DEFINE param functions -----------------------
     def _defineParams(self, form):


### PR DESCRIPTION
An important bug fix for init model and subtract protocols. createReader was used without pixelSize kwarg resulting in readerBase defaulting to 1.0 A/px. These protocols do not use readSetOfParticles where the pixel size is updated. Other protocols already had pixelSize kwarg.