### PR TITLE
fix #294

### DIFF
--- a/relion/convert/dataimport.py
+++ b/relion/convert/dataimport.py
@@ -116,7 +116,8 @@ class RelionImport:
                 self._starFile, partSet,
                 preprocessImageRow=None,
                 postprocessImageRow=self._postprocessImageRow,
-                readAcquisition=True, alignType=self.alignType)
+                readAcquisition=False, alignType=self.alignType,
+                pixelSize=self._pixelSize)
 
         if self._micIdOrName:
             self.protocol._defineOutputs(outputMicrographs=self.micSet)


### PR DESCRIPTION
readAcquisition was always true for readSetOfParticles, now it's set to False during import and pixelsize and optics are overwritten with values from the protocol (otherwise they are obtained from the star file)

readSetOfParticles is used only in dataimport and expand symmetry protocol.