### PR TITLE
Minor Fix related to Optics Groups

### DIFF
--- a/relion/__init__.py
+++ b/relion/__init__.py
@@ -32,7 +32,7 @@ import pwem
 from .constants import *
 
 
-__version__ = '4.0b5'
+__version__ = '4.0b6'
 _logo = "relion_logo.jpg"
 _references = ['Scheres2012a', 'Scheres2012b', 'Kimanius2016', 'Zivanov2018']
 

--- a/relion/convert/convert31.py
+++ b/relion/convert/convert31.py
@@ -73,7 +73,8 @@ class OpticsGroups:
 
     def __store(self, og):
         self._dict[og.rlnOpticsGroup] = og
-        self._dictName[og.rlnOpticsGroupName] = og
+        groupName = og.rlnOpticsGroupName if hasattr(og, 'rlnOpticsGroupName') else 'optics_group_%s' % og.rlnOpticsGroup
+        self._dictName[groupName] = og
 
     def __getitem__(self, item):
         if isinstance(item, int):


### PR DESCRIPTION
This minor change will allow us to successfully deal with star files without _rlnOpticsGroupName in the optics table.