### PR TITLE
Fix when there are not micrographs to extract

### DIFF
--- a/relion/__init__.py
+++ b/relion/__init__.py
@@ -32,7 +32,7 @@ import pwem
 from .constants import *
 
 
-__version__ = '4.0b6'
+__version__ = '4.0b7'
 _logo = "relion_logo.jpg"
 _references = ['Scheres2012a', 'Scheres2012b', 'Kimanius2016', 'Zivanov2018']
 

--- a/relion/protocols/protocol_extract_particles.py
+++ b/relion/protocols/protocol_extract_particles.py
@@ -159,6 +159,9 @@ class ProtRelionExtractParticles(ProtExtractParticles, ProtRelionBase):
         self._extractMicrographList([mic], params)
 
     def _extractMicrographList(self, micList, params):
+        if not micList:  # do not process when empty list, need to check this properly
+            return
+
         workingDir = self.getWorkingDir()
         micsStar = self._getMicsStar(micList)
         og = OpticsGroups.fromImages(self.getInputMicrographs())


### PR DESCRIPTION
When the extraction protocols is stopped and then continued, it seems that there is a empty list of micList, which then makes the whole protocol to fail