### PR TITLE
Protocol autopickLog allows pointer for the box size param

### DIFF
--- a/relion/protocols/protocol_autopick_log.py
+++ b/relion/protocols/protocol_autopick_log.py
@@ -60,6 +60,7 @@ class ProtRelionAutopickLoG(ProtRelionAutopickBase):
 
         form.addParam('boxSize', params.IntParam,
                       label='Box size (px)',
+                      allowsPointers=True,
                       help="Box size in pixels.")
 
         group = form.addGroup('Laplacian of Gaussian')


### PR DESCRIPTION
One line added to the box size addParam (allowsPointers=True) 