### PR TITLE
Replace line.addParam to group.addParam to allow input pointers in protocol autopick log

### DIFF
--- a/relion/protocols/protocol_autopick_log.py
+++ b/relion/protocols/protocol_autopick_log.py
@@ -68,10 +68,10 @@ class ProtRelionAutopickLoG(ProtRelionAutopickBase):
         line = group.addLine('Diameter for LoG filter (A)',
                              help="Min and Max of LoG filter")
 
-        line.addParam('minDiameter', params.IntParam, default=200, allowsPointers=True,
+        group.addParam('minDiameter', params.IntParam, default=200, allowsPointers=True,
                       label='Min')
 
-        line.addParam('maxDiameter', params.IntParam, default=250, allowsPointers=True,
+        group.addParam('maxDiameter', params.IntParam, default=250, allowsPointers=True,
                       label='Max')
 
         group.addParam('areParticlesWhite', params.BooleanParam,

--- a/relion/protocols/protocol_autopick_log.py
+++ b/relion/protocols/protocol_autopick_log.py
@@ -65,14 +65,11 @@ class ProtRelionAutopickLoG(ProtRelionAutopickBase):
 
         group = form.addGroup('Laplacian of Gaussian')
 
-        line = group.addLine('Diameter for LoG filter (A)',
-                             help="Min and Max of LoG filter")
-
         group.addParam('minDiameter', params.IntParam, default=200, allowsPointers=True,
-                      label='Min')
+                       label='Min diameter (A)')
 
         group.addParam('maxDiameter', params.IntParam, default=250, allowsPointers=True,
-                      label='Max')
+                       label='Max diameter (A)')
 
         group.addParam('areParticlesWhite', params.BooleanParam,
                        default=False,


### PR DESCRIPTION
Line object in the protocol form does not allow an input pointer. Therefore, min/maxDiameter parameters had to be change to groupLine params in the protocol form of autopick log. 

We have a bit of a hurry with this, we would like to have this functionality for a project with the ESRF and a course in Paris. 

Appreciate your comprehension,
Daniel. 