### PR TITLE
protocol_crop_resize produce the output file but not the scipion output object

### DIFF
--- a/relion/protocols/protocol_crop_resize.py
+++ b/relion/protocols/protocol_crop_resize.py
@@ -116,7 +116,6 @@ class ProtRelionResizeVolume(ProtPreprocessVolumes):
             vol.copyInfo(volInput)
             vol.setLocation(self._getFileName('output_vol', volId=1))
             vol.setSamplingRate(self._getNewSampling())
-            #self._defineOutputs(outputVolume=vol)
             self._defineOutputs(outputVol=vol)
         else:
             volumes = self._createSetOfVolumes()

--- a/relion/protocols/protocol_crop_resize.py
+++ b/relion/protocols/protocol_crop_resize.py
@@ -116,7 +116,8 @@ class ProtRelionResizeVolume(ProtPreprocessVolumes):
             vol.copyInfo(volInput)
             vol.setLocation(self._getFileName('output_vol', volId=1))
             vol.setSamplingRate(self._getNewSampling())
-            self._defineOutputs(outputVolume=vol)
+            #self._defineOutputs(outputVolume=vol)
+            self._defineOutputs(outputVol=vol)
         else:
             volumes = self._createSetOfVolumes()
             volumes.copyInfo(volInput)
@@ -126,7 +127,7 @@ class ProtRelionResizeVolume(ProtPreprocessVolumes):
                 vol.setLocation(self._getFileName('output_vol', volId=i+1))
                 vol.setSamplingRate(self._getNewSampling())
                 volumes.append(vol)
-            self._defineOutputs(outputVolumes=volumes)
+            self._defineOutputs(outputVol=volumes)
 
         self._defineTransformRelation(self.inputVolumes, self.outputVol)
 


### PR DESCRIPTION
protocol_crop_resize fails, the protocol is executed but the scipion object is not created. The problem seems to be in these lines

actual line
            self._defineOutputs(outputVolume=vol)
suggested change
            self._defineOutputs(outputVol=vol)


if the change is not incorporated then the protocol fails in line

        self._defineTransformRelation(self.inputVolumes, self.outputVol)


And alternative solution would be to use two differente lines

         self._defineTransformRelation(self.inputVolumes, self.outputVol)

one for ta single volume the other for a set of volumes