### PR TITLE
Update README.rst

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -50,6 +50,13 @@ b) Developer's version
 
       git clone https://github.com/scipion-em/scipion-em-relion.git
 
+
+   * change to devel branch
+
+   .. code-block::
+
+      git checkout devel
+
    * install
 
    .. code-block::


### PR DESCRIPTION
It wasn't indicating switching to devel. 

I can see there are other options:

git clone devel branch in a single command

make devel the default branch.