### PR TITLE
4.0.9

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,3 +1,4 @@
+4.0.9: fix output pixel size in the resize volume protocol
 4.0.8: better integration with sidesplitter plugin
 4.0.7: fix typo in half2 output name from MB protocol
 4.0.6:

--- a/relion/__init__.py
+++ b/relion/__init__.py
@@ -33,7 +33,7 @@ import pwem
 from .constants import *
 
 
-__version__ = '4.0.8'
+__version__ = '4.0.9'
 _logo = "relion_logo.jpg"
 _references = ['Scheres2012a', 'Scheres2012b', 'Kimanius2016',
                'Zivanov2018', 'Kimanius2021']

--- a/relion/protocols/_legacy/protocol31_initialmodel.py
+++ b/relion/protocols/_legacy/protocol31_initialmodel.py
@@ -408,8 +408,6 @@ class ProtRelionInitialModel(ProtInitialVolume, ProtRelionBase):
         if not self.doContinue:
             args.update({'--sym': self.symmetryGroup.get()})
         args['--pad'] = 1 if self.skipPadding else 2
-        if self.skipGridding:
-            args['--skip_gridding'] = ''
 
         self._setSGDArgs(args)
         self._setSamplingArgs(args)

--- a/relion/protocols/protocol_base.py
+++ b/relion/protocols/protocol_base.py
@@ -736,11 +736,7 @@ class ProtRelionBase(EMProtocol):
                                    '(i.e. use --pad 1) gives nearly as good results '
                                    'as using --pad 2, but some artifacts may appear '
                                    'in the corners from signal that is folded back.')
-            form.addParam('skipGridding', BooleanParam, default=True,
-                          label='Skip gridding',
-                          help='If set to Yes, the calculations will '
-                               'skip gridding in the M step to save time, '
-                               'typically with just as good results.')
+            form.addHidden('skipGridding', BooleanParam, default=True)  # removed from relion-4.0-stable
 
         form.addParam('allParticlesRam', BooleanParam, default=False,
                       label='Pre-read all particles into RAM?',
@@ -1104,8 +1100,6 @@ class ProtRelionBase(EMProtocol):
         # Padding can be set in a normal run or in a continue
         if self.IS_3D:
             args['--pad'] = 1 if self.skipPadding else 2
-            if self.skipGridding:
-                args['--skip_gridding'] = ''
 
         self._setSamplingArgs(args)
         self._setMaskArgs(args)

--- a/relion/protocols/protocol_initialmodel.py
+++ b/relion/protocols/protocol_initialmodel.py
@@ -355,8 +355,6 @@ class ProtRelionInitialModel(ProtInitialVolume, ProtRelionBase):
             args['--flatten_solvent'] = ''
         if not self.doContinue:
             args['--sym'] = 'C1' if self.runInC1 else self.symmetryGroup.get()
-        if self.skipGridding:
-            args['--skip_gridding'] = ''
 
         self._setGradArgs(args)
         self._setSamplingArgs(args)

--- a/relion/protocols/protocol_motioncor.py
+++ b/relion/protocols/protocol_motioncor.py
@@ -577,6 +577,10 @@ class ProtRelionMotioncor(ProtAlignMovies, ProtRelionBase):
             ogDict.update({'rlnEERUpsampling': self.eerSampling.get() + 1,
                            'rlnEERGrouping': self.eerGroup.get()})
 
+        gain = self.inputMovies.get().getGain()
+        if gain:
+            ogDict['rlnMicrographGainName'] = gain
+
         if outputName not in self.updatedSets:
             og = OpticsGroups.fromImages(outputSet)
             og.updateAll(**ogDict)

--- a/relion/protocols/protocol_multibody.py
+++ b/relion/protocols/protocol_multibody.py
@@ -444,8 +444,6 @@ Also note that larger bodies should be above smaller bodies in the STAR file. Fo
                 pwutils.createAbsLink(os.path.abspath(maskBody1), maskFn)
 
         args['--continue'] = fnOptimiser
-        if self.skipGridding:
-            args['--skip_gridding'] = ''
 
         self._setComputeArgs(args)
 


### PR DESCRIPTION
- skip_gridding is now removed from relion4
- fix output pixel size in resize volumes protocol
- set gain file in optics table if found in input movies