### PR TITLE
Added the option to use SCIPION_SCRATCH

### DIFF
--- a/relion/constants.py
+++ b/relion/constants.py
@@ -49,6 +49,10 @@ V5_0 = '5.0'
 MASK_FILL_ZERO = 0
 MASK_FILL_NOISE = 1
 
+SCRATCH_DISABLED = 0
+USE_SCIPION_SCRATCH = 1
+USE_CUSTOM_SCRATCH = 2
+
 ANGULAR_SAMPLING_LIST = ['30', '15', '7.5', '3.7', '1.8', '0.9', '0.5',
                          '0.2', '0.1', '0.06', '0.03', '0.01', '0.007', '0.004']
 


### PR DESCRIPTION
In the past, I found it quite tedious to manually specify Relion's scratch directory every time I ran a protocol. Additionally, when running multiple Relion protocols simultaneously, each scratch directory had to be carefully chosen to be unique. Otherwise, concurrent executions would conflict with each other.

Luckily, the `SCIPION_SCRATCH` configuration variable automatizes both of these issues. In this PR, I am adding the functionality to use this Scipion feature within Relion protocols.