### PR TITLE
Always add Dynamight batch size flag to form and program call

### DIFF
--- a/relion/protocols/protocol_dynamight.py
+++ b/relion/protocols/protocol_dynamight.py
@@ -89,7 +89,7 @@ class ProtRelionDynaMight(ProtAnalysis3D, ProtRelionBase):
                       label='Select previous run',
                       help='Select a previous run to analyse.')
         
-        group.addParam('batchSize', params.IntParam, default=10,
+        form.addParam('batchSize', params.IntParam, default=10,
                        label="Backprojection batchsize",
                        help="Number of images to process in parallel. "
                             "This will speed up the calculation, but will "

--- a/relion/protocols/protocol_dynamight.py
+++ b/relion/protocols/protocol_dynamight.py
@@ -88,6 +88,15 @@ class ProtRelionDynaMight(ProtAnalysis3D, ProtRelionBase):
                       condition='doContinue', allowsNull=True,
                       label='Select previous run',
                       help='Select a previous run to analyse.')
+        
+        group.addParam('batchSize', params.IntParam, default=10,
+                       label="Backprojection batchsize",
+                       help="Number of images to process in parallel. "
+                            "This will speed up the calculation, but will "
+                            "cost GPU memory. Try how high you can go on "
+                            "your GPU, given your box size and size of the "
+                            "neural network. If you get errors regarding "
+                            "the size of the tensors, try 120. ")
 
         form.addParam('inputParticles', params.PointerParam,
                       allowsNull=True,
@@ -177,15 +186,6 @@ class ProtRelionDynaMight(ProtAnalysis3D, ProtRelionBase):
                             "in the GPU memory, which will speed up the "
                             "calculations, but you need to have enough GPU "
                             "memory to do this.")
-
-        group.addParam('batchSize', params.IntParam, default=10,
-                       label="Backprojection batchsize",
-                       help="Number of images to process in parallel. "
-                            "This will speed up the calculation, but will "
-                            "cost GPU memory. Try how high you can go on "
-                            "your GPU, given your box size and size of the "
-                            "neural network. If you get errors regarding "
-                            "the size of the tensors, try 120. ")
 
         form.addParallelSection(threads=4, mpi=0)
 

--- a/relion/protocols/protocol_dynamight.py
+++ b/relion/protocols/protocol_dynamight.py
@@ -179,13 +179,13 @@ class ProtRelionDynaMight(ProtAnalysis3D, ProtRelionBase):
                             "memory to do this.")
 
         group.addParam('batchSize', params.IntParam, default=10,
-                       condition='doContinue and doDeform',
                        label="Backprojection batchsize",
                        help="Number of images to process in parallel. "
                             "This will speed up the calculation, but will "
                             "cost GPU memory. Try how high you can go on "
                             "your GPU, given your box size and size of the "
-                            "neural network.")
+                            "neural network. If you get errors regarding "
+                            "the size of the tensors, try 120. ")
 
         form.addParallelSection(threads=4, mpi=0)
 

--- a/relion/protocols/protocol_dynamight.py
+++ b/relion/protocols/protocol_dynamight.py
@@ -237,6 +237,7 @@ class ProtRelionDynaMight(ProtAnalysis3D, ProtRelionBase):
             f"--regularization-factor {self.regularizeFactor}",
             f"--n-threads {self.numberOfThreads}",
             f"--gpu-id {self.gpuList.get()}",
+            f"--batch-size {self.batchSize.get()}",
             "--preload-images" if self.allParticlesRam else ""
         ]
 
@@ -275,7 +276,6 @@ class ProtRelionDynaMight(ProtAnalysis3D, ProtRelionBase):
             params = [
                 "deformable-backprojection",
                 self._getExtraPath(),
-                f"--batch-size {self.batchSize.get()}",
                 f"--checkpoint-file {checkpoint_file}",
                 f"--gpu-id {self.gpuList.get()}",
                 "--preload-images" if self.allParticlesRam else ""


### PR DESCRIPTION
In some cases, Dynamight will fail to run [such as here](https://github.com/3dem/relion/issues/1047) giving "Index tensor must have the same number of dimensions as self tensor".

The solution proposed by the author is adding a different --batchSize than the default (120 is given as an example). However this is not possible through Scipion as the option for --batchSize is only visible when "tasks" is used to continue a run. This PR makes the batch size option always visible, in the general section and with default value of 120.

Wbw,
Mikel